### PR TITLE
Move I2C class into hal/ subfolder

### DIFF
--- a/inc/ErrorNo.h
+++ b/inc/ErrorNo.h
@@ -1,37 +1,7 @@
 #ifndef ERROR_NO_H
 #define ERROR_NO_H
 
-/**
-  * Error codes used in the micro:bit runtime.
-  * These may be returned from functions implemented in the micro:bit runtime.
-  */
-enum ErrorCode{
-
-    // No error occurred.
-    MICROBIT_OK = 0,
-
-    // Invalid parameter given.
-    MICROBIT_INVALID_PARAMETER = -1001, 
-
-    // Requested operation is unspupported.
-    MICROBIT_NOT_SUPPORTED = -1002, 
-
-    // Device calibration errors
-    MICROBIT_CALIBRATION_IN_PROGRESS = -1003, 
-    MICROBIT_CALIBRATION_REQUIRED = -1004,
-
-    // The requested operation could not be performed as the device has run out of some essential resource (e.g. allocated memory)
-    MICROBIT_NO_RESOURCES = -1005,
-
-    // The requested operation could not be performed as some essential resource is busy (e.g. the display)
-    MICROBIT_BUSY = -1006,
-
-    // The requested operation was cancelled before it completed.
-    MICROBIT_CANCELLED = -1007,
-
-    // I2C Communication error occured (typically I2C module on processor has locked up.) 
-    MICROBIT_I2C_ERROR = -1010 
-};
+#include "hal/ErrorNo.h"
 
 /**
   * Error codes used in the micro:bit runtime.
@@ -42,7 +12,7 @@ enum PanicCode{
     // entered where the panic code is diplayed.
 
     // Out out memory error. Heap storage was requested, but is not available.
-    MICROBIT_OOM = 20, 
+    MICROBIT_OOM = 20,
 
     // Corruption detected in the micro:bit heap space
     MICROBIT_HEAP_ERROR = 30,

--- a/inc/MicroBit.h
+++ b/inc/MicroBit.h
@@ -3,7 +3,8 @@
 
 #include "mbed.h"
 
-#include "MicroBitConfig.h"  
+#include "MicroBitConfig.h"
+#include "hal/MicroBitHal.h"
 #include "MicroBitHeapAllocator.h"
 #include "MicroBitPanic.h"
 #include "ErrorNo.h"
@@ -15,7 +16,6 @@
 #include "MicroBitFont.h"
 #include "MicroBitEvent.h"
 #include "DynamicPwm.h"
-#include "MicroBitI2C.h"
 #include "MESEvents.h"
 
 #include "MicroBitButton.h"
@@ -58,16 +58,12 @@
 #define NRF51822_RNG_ADDRESS            0x4000D000
 
 
-// mbed pin assignments of core components.
-#define MICROBIT_PIN_SDA                P0_30
-#define MICROBIT_PIN_SCL                P0_0
-
 /**
   * Class definition for a MicroBit device.
   *
   * Represents the device as a whole, and includes member variables to that reflect the components of the system.
   */
-class MicroBit
+class MicroBit : public MicroBitHal
 {                                  
     private:
     
@@ -81,9 +77,6 @@ class MicroBit
 
     // Periodic callback
     Ticker                  systemTicker;
-
-    // I2C Interface
-    MicroBitI2C             i2c;  
     
     // Serial Interface
     MicroBitSerial          serial;   

--- a/inc/hal/ErrorNo.h
+++ b/inc/hal/ErrorNo.h
@@ -1,0 +1,37 @@
+#ifndef ERROR_NO_HAL_H
+#define ERROR_NO_HAL_H
+
+/**
+  * Error codes used in the micro:bit runtime.
+  * These may be returned from functions implemented in the micro:bit runtime.
+  */
+enum ErrorCode{
+
+    // No error occurred.
+    MICROBIT_OK = 0,
+
+    // Invalid parameter given.
+    MICROBIT_INVALID_PARAMETER = -1001,
+
+    // Requested operation is unspupported.
+    MICROBIT_NOT_SUPPORTED = -1002,
+
+    // Device calibration errors
+    MICROBIT_CALIBRATION_IN_PROGRESS = -1003,
+    MICROBIT_CALIBRATION_REQUIRED = -1004,
+
+    // The requested operation could not be performed as the device has run out of some essential resource (e.g. allocated memory)
+    MICROBIT_NO_RESOURCES = -1005,
+
+    // The requested operation could not be performed as some essential resource is busy (e.g. the display)
+    MICROBIT_BUSY = -1006,
+
+    // The requested operation was cancelled before it completed.
+    MICROBIT_CANCELLED = -1007,
+
+    // I2C Communication error occured (typically I2C module on processor has locked up.)
+    MICROBIT_I2C_ERROR = -1010
+};
+
+
+#endif

--- a/inc/hal/MicroBitHal.h
+++ b/inc/hal/MicroBitHal.h
@@ -1,0 +1,25 @@
+#ifndef MICROBIT_HAL_H
+#define MICROBIT_HAL_H
+
+#include "hal/MicroBitI2C.h"
+
+// mbed pin assignments of core components.
+#define MICROBIT_PIN_SDA                P0_30
+#define MICROBIT_PIN_SCL                P0_0
+
+/**
+  * Class definition for a minimal abstract layer of the MicroBit device.
+  *
+  * Represents the device as a whole, and includes member variables to that reflect the components of the system.
+  */
+class MicroBitHal
+{
+
+    public:
+
+    // I2C Interface
+    static MicroBitI2C i2c;
+
+};
+
+#endif

--- a/inc/hal/MicroBitI2C.h
+++ b/inc/hal/MicroBitI2C.h
@@ -14,22 +14,22 @@
 class MicroBitI2C : public I2C
 {
     uint8_t retries;
-    
+
     public:
-    
+
     /**
-      * Constructor. 
+      * Constructor.
       * Create an instance of i2c
       * @param sda the Pin to be used for SDA
       * @param scl the Pin to be used for SCL
       * Example:
-      * @code 
+      * @code
       * MicroBitI2C i2c(MICROBIT_PIN_SDA, MICROBIT_PIN_SCL);
       * @endcode
       * @note this should prevent i2c lockups as well.
       */
     MicroBitI2C(PinName sda, PinName scl);
-  
+
     /**
       * Performs a complete read transaction. The bottom bit of the address is forced to 1 to indicate a read.
       *
@@ -41,12 +41,12 @@ class MicroBitI2C : public I2C
       * @return MICROBIT_OK on success, MICROBIT_I2C_ERROR if an unresolved read failure is detected.
       */
     int read(int address, char *data, int length, bool repeated = false);
-   
+
     /**
       * Performs a complete write transaction. The bottom bit of the address is forced to 0 to indicate a write.
       *
       * @address 8-bit I2C slave address [ addr | 0 ]
-      * @data Pointer to the byte-arraycontaining the data to write 
+      * @data Pointer to the byte-arraycontaining the data to write
       * @length Number of bytes to write
       * @repeated Repeated start, true - don't send stop at end.
       *

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,7 +7,8 @@ enable_language(ASM)
 
 set(YOTTA_AUTO_MICROBIT-DAL_CPP_FILES
     "MicroBitSuperMain.cpp"
-    "MicroBitI2C.cpp"
+    "hal/MicroBitHal.cpp"
+    "hal/MicroBitI2C.cpp"
     "MicroBitMultiButton.cpp"
     "MicroBitFont.cpp"
     "MicroBit.cpp"
@@ -42,7 +43,7 @@ set(YOTTA_AUTO_MICROBIT-DAL_CPP_FILES
 execute_process(WORKING_DIRECTORY "../../yotta_modules/${PROJECT_NAME}" COMMAND "git" "log" "--pretty=format:%h" "-n" "1" OUTPUT_VARIABLE git_hash)
 execute_process(WORKING_DIRECTORY "../../yotta_modules/${PROJECT_NAME}" COMMAND "git" "rev-parse" "--abbrev-ref" "HEAD" OUTPUT_VARIABLE git_branch OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if (${git_branch} STREQUAL "master")
+if ("${git_branch}" STREQUAL "master")
     set(MICROBIT_DAL_VERSION_STRING "${YOTTA_MICROBIT_DAL_VERSION_STRING}")
 else()
     set(MICROBIT_DAL_VERSION_STRING "${YOTTA_MICROBIT_DAL_VERSION_STRING}-${git_branch}-g${git_hash}")

--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -57,7 +57,6 @@ void bleDisconnectionCallback(Gap::Handle_t handle, Gap::DisconnectionReason_t r
   */
 MicroBit::MicroBit() : 
     flags(0x00),
-    i2c(MICROBIT_PIN_SDA, MICROBIT_PIN_SCL),
     serial(USBTX, USBRX),
     MessageBus(),
     display(MICROBIT_ID_DISPLAY, MICROBIT_DISPLAY_WIDTH, MICROBIT_DISPLAY_HEIGHT),

--- a/source/hal/MicroBitHal.cpp
+++ b/source/hal/MicroBitHal.cpp
@@ -1,0 +1,5 @@
+
+#include "hal/MicroBitHal.h"
+
+MicroBitI2C MicroBitHal::i2c(MICROBIT_PIN_SDA, MICROBIT_PIN_SCL);
+

--- a/source/hal/MicroBitI2C.cpp
+++ b/source/hal/MicroBitI2C.cpp
@@ -1,15 +1,16 @@
 #include "mbed.h"
-#include "MicroBit.h"
+#include "hal/MicroBitI2C.h"
+#include "hal/ErrorNo.h"
 #include "twi_master.h"
 #include "nrf_delay.h"
 
 /**
-  * Constructor. 
+  * Constructor.
   * Create an instance of i2c
   * @param sda the Pin to be used for SDA
   * @param scl the Pin to be used for SCL
   * Example:
-  * @code 
+  * @code
   * MicroBitI2C i2c(MICROBIT_PIN_SDA, MICROBIT_PIN_SCL);
   * @endcode
   * @note this should prevent i2c lockups as well.
@@ -32,12 +33,12 @@ MicroBitI2C::MicroBitI2C(PinName sda, PinName scl) : I2C(sda,scl)
 int MicroBitI2C::read(int address, char *data, int length, bool repeated)
 {
     int result = I2C::read(address,data,length,repeated);
-    
+
     //0 indicates a success, presume failure
     while(result != 0 && retries < MICROBIT_I2C_MAX_RETRIES)
     {
         _i2c.i2c->EVENTS_ERROR = 0;
-        _i2c.i2c->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos; 
+        _i2c.i2c->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
         _i2c.i2c->POWER        = 0;
         nrf_delay_us(5);
         _i2c.i2c->POWER        = 1;
@@ -46,11 +47,11 @@ int MicroBitI2C::read(int address, char *data, int length, bool repeated)
         result = I2C::read(address,data,length,repeated);
         retries++;
     }
-    
+
     if(result != 0)
         return MICROBIT_I2C_ERROR;
-   
-    retries = 0; 
+
+    retries = 0;
     return MICROBIT_OK;
 }
 
@@ -58,34 +59,35 @@ int MicroBitI2C::read(int address, char *data, int length, bool repeated)
  * Performs a complete write transaction. The bottom bit of the address is forced to 0 to indicate a write.
  *
  * @address 8-bit I2C slave address [ addr | 0 ]
- * @data Pointer to the byte-arraycontaining the data to write 
+ * @data Pointer to the byte-arraycontaining the data to write
  * @length Number of bytes to write
  * @repeated Repeated start, true - don't send stop at end.
  *
  * @return MICROBIT_OK on success, MICROBIT_I2C_ERROR if an unresolved write failure is detected.
  */
 int MicroBitI2C::write(int address, const char *data, int length, bool repeated)
-{   
+{
     int result = I2C::write(address,data,length,repeated);
-    
+
     //0 indicates a success, presume failure
     while(result != 0 && retries < MICROBIT_I2C_MAX_RETRIES)
     {
         _i2c.i2c->EVENTS_ERROR = 0;
-        _i2c.i2c->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos; 
+        _i2c.i2c->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
         _i2c.i2c->POWER        = 0;
         nrf_delay_us(5);
         _i2c.i2c->POWER        = 1;
         _i2c.i2c->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
-        
+
         twi_master_init_and_clear();
         result = I2C::write(address,data,length,repeated);
         retries++;
     }
-    
+
     if(result != 0)
         return MICROBIT_I2C_ERROR;
-        
-    retries = 0; 
+
+    retries = 0;
     return MICROBIT_OK;
 }
+


### PR DESCRIPTION
Moves the `MicroBitI2C` class into the `/hal/` sub folder. 
This is the first step towards fixing https://github.com/lancaster-university/microbit-dal/issues/40