### PR TITLE
Remove unnecessary uBit.serial.baud() calls

### DIFF
--- a/source/MicroBit.cpp
+++ b/source/MicroBit.cpp
@@ -93,9 +93,6 @@ MicroBit::MicroBit() :
   */
 void MicroBit::init()
 {   
-    // Set the default baud rate for the serial port.`
-    uBit.serial.baud(115200);
-        
     //add the display to the systemComponent array
     addSystemComponent(&uBit.display);
     

--- a/source/MicroBitSuperMain.cpp
+++ b/source/MicroBitSuperMain.cpp
@@ -14,7 +14,6 @@ int main()
 #if CONFIG_ENABLED(MICROBIT_DBG)
 
     // For diagnostics. Gives time to open the console window. :-) 
-    uBit.serial.baud(115200);
     for (int i=3; i>0; i--)
     {
         uBit.serial.printf("=== SUPERMAIN: Starting in %d ===\n", i);


### PR DESCRIPTION
The serial baud rate is set duing construction of the uBit object.  We
don't need to do it again, and especially with fixed values that can't
be overridden.

Addresses issue #37
