### PR TITLE
microbit: Added basic gesture recognition into MicroBitAccelerometer

### DIFF
--- a/inc/MicroBitComponent.h
+++ b/inc/MicroBitComponent.h
@@ -42,6 +42,7 @@
 #define MICROBIT_ID_IO_P20              25          //SDA
 
 #define MICROBIT_ID_BUTTON_AB           26          // Button A+B multibutton
+#define MICROBIT_ID_GESTURE             27          // Gesture events 
 
 #define MICROBIT_ID_NOTIFY              1023          // Notfication channel, for general purpose synchronisation 
 #define MICROBIT_ID_NOTIFY_ONE          1022          // Notfication channel, for general purpose synchronisation 


### PR DESCRIPTION
The following postures of the device are now detected:
- TILT_UP
- TILT_DOWN
- TILT_LEFT
- TILT_RIGHT
- FACE_UP
- FACE_DOWN

In addition, the following gestures are inferred:
- NONE
- SHAKE
- FREEFALL
- WHEEE (>=3g)
- SICK (>=5g)
- UNCONSCIOUS (>=8g)

Events are now triggered on the MessageBus upon the transition from one posture/gesture to another, and a synchronous getGesture() method is now also provided to interrogate the last gesture recognised.

It should be noted that the default accelerator range of +/-2g will be insufficient to detect some of the events noted above, and MicroBitAccelerometer::setRange() should be used to increase the range if required.
