### PR TITLE
README.md: Update for modern yotta, gcc first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,75 @@
 # microbit-dal
 
-## Building a project for the micro:bit using Yotta 
+## Building a project for the micro:bit using yotta 
 
-Instead of using the online IDE, Yotta can be used to provide an equivalent offline experience. The current compilers that are available are:
+The micro:bit DAL is built on top of [mbed](http://mbed.com) and hence uses [yotta](http://yotta.mbed.com) as an offline build system.
+
+If you'd like to use the mbed online IDE instead, you can find instructions at [the mbed Developer site](https://developer.mbed.org/platforms/Microbit/)
+
+
+When using `yotta` to build micro:bit projects there are currently two supported toolchains:
 
 * GCC
 * ARMCC
 
 ## Getting Started
 
-### 1. Install Yotta 
-The first step is to get Yotta onto your machine, to do this follow the install guide [here](http://docs.yottabuild.org/#installing)
+### 1. Install yotta and dependencies
 
-**Note: if you are on windows, dependencies will be missed as of 8/8/15, please use the helper script located [here](https://github.com/ARMmbed/yotta/blob/master/get_yotta.py).**
+The first step is to get `yotta` and its dependencies onto your machine, to do this follow the install guide [here](http://docs.yottabuild.org/#installing)
+
+
+For the micro:bit targets you currently still need the srecord tools, which can be installed on **Ubuntu** using
+```
+sudo apt-get install srecord
+```
+
+On **Mac OS X** you can use brew (`brew install srecord`), or you can install it manually from [here](http://srecord.sourceforge.net/) if you are on **Windows**. srecord is used to create the final binaries for the micro:bit so is an essential dependency.
+
 
 ### 2. Fetch the example project
 
-If your install has gone correctly, and you have all dependencies installed, the next step is to fetch the example project using the runtime from GitHub.
-
-```
+```bash
 git clone https://github.com/lancaster-university/microbit
+cd microbit #The following instructions assume you're in the example directory
 ```
 
-**Note: To successfully build this project you will need access to the microbit-dal private repository, if you need access please email me at j.devine@lancaster.ac.uk.**
+**Note: To successfully build this project before the micro:bit DAL is open sourced, you will need access to the microbit-dal private repository, if you need access please email me at j.devine@lancaster.ac.uk.**
 
-### 3. Try to build
-Building rarely works first time due to dependencies currently not being installed by Yotta, so the next step is to **try** to build.
+### 3. Set your yotta target
 
-The default yotta target you will receive when you pull the aforementioned repo is bbc-microbit-classic-armcc, you can use the following command to print your current target in Yotta:
+A `yotta` target contains the information required by `yotta` in order to build a project for a specific combination of hardware. This includes the type of compiler. The microbit projects can build with both `armcc` and `gcc`, but as it gets installed with the `yotta` installer, we'll use `gcc` by default and choose a micro:bit specific target that knows about the hardware on the board.
 
-```
-yt target
-
-bbc-microbit-classic-armcc 0.0.5
-mbed-armcc 0.0.8
-```
-
-If you do not have armcc installed (or don't have a license for Keil), then you will need to use GCC. To swap to the GCC target run:
+You can use either `yotta` or `yt`, which is far easier to type!
 
 ```
 yt target bbc-microbit-classic-gcc
 ```
 
-Then you should **try** to build using the following command:
+The 'classic' part of this target name referes to the fact that the micro:bit uses "mbed Classic" (see https://developer.mbed.org/) which is the version of mbed before mbed OS. It is also possible to use mbed OS on the micro:bit (see [here](https://www.mbed.com/en/development/hardware/boards/)) but the DAL has not yet been ported to use mbed OS. 
+ 
+You only need to set the target once per project. All future `yotta` commands will use this target information (for example, when resolving dependencies).
+
+### 4. Build the project
 
 ```
 yt build
 ```
 
-**NOTE:
-To build the final hex files for the micro:bit, you will need to install the srec which can be installed via brew (`brew install srecord`), or you can install it manually from [here](http://srecord.sourceforge.net/).**
-
-### 4. Flash your micro:bit
+### 5. Flash your micro:bit
 The final step is to check your hex works. 
 
-The yotta build command will place files in `/build/<TARGET_NAME>/source`. The file you will need to flash will be microbit-combined.hex. Simply drag and drop the hex.
+The `yotta build` command will place files in `/build/<TARGET_NAME>/source`. The file you will need to flash will be microbit-combined.hex. Simply drag and drop the hex.
 
+In the case of our example, using `bbc-microbit-classic-gcc` we could flash the micro:bit (assuming it is plugged in and mounted at `/media/MICROBIT`) as follows:
+
+```
+cp ./build/bbc-microbit-classic-gcc/source/microbit-combined.hex /media/MICROBIT
+```
 The expected result will be that the micro:bit will scroll `BELLO! :)` on its display.
+
+Note that if you'd like to copy the file from the command line, you can use the following command in any `yotta` project to do so, though it assumes you have only one micro:bit plugged in:
+
+```
+cp build/$(yt --plain target | head -n 1 | cut -f 1 -d' ')/source/$(yt --plain ls | head -n 1 | cut -f 1 -d' ')-combined.hex /media/MICROBIT/
+```


### PR DESCRIPTION
Quite a lot has chanced since the original instructions were written,
and so this commit updates the instructions to be a little more useful.

Most significantly, we now walk through the process with gcc not
armcc, as this is now the default toolchain for builds of the
micro:bit DAL by both Microsoft and Lancaster