### PR TITLE
MicroBit: Filesystem

### DIFF
--- a/inc/MicroBitFile.h
+++ b/inc/MicroBitFile.h
@@ -5,63 +5,77 @@
 #include "MicroBit.h"
 
 /**
- * @file MicroBitFile.h
- * @author Alex King
- * @date 6 Mar 2016
- *
- * @brief API for POSIX-like file system interface: open/close/read/write.
- *
- * Class is divided into two parts: public POSIX methods:
- * open/close/read/write/unlink
- *
- * And private Master Boot Record methods, to 
- * access and change entries in the MBR page - which stores file 
- * state information.
- */
+  * @file MicroBitFile.h
+  * @author Alex King
+  * @date 6 Mar 2016
+  *
+  * @brief API for POSIX-like file system interface: open/close/read/write.
+  *
+  * -- Basic overview of how the file system works:
+  * All file meta data is stored in the first page. Each file has a record
+  * entry (struct mbr_t), which stores:
+  *  - Filename
+  *  - File size
+  *  - An enumerated list of blocks that store the file data itself.
+  * 
+  * The table housing these records is referred to as the Master Block
+  * Record (MBR), and looks something like this:
+  *  {"file1.txt",   5000,   {1,2,3,6}}  // 5000-byte file, in blocks 1,2,3,6
+  *  {"file02.txt",   200,   {5}}        // 200 byte file in a single block
+  * 
+  * The first MBR entry is reserved, and is used only to store a list of 
+  * currently available blocks for writing.
+  * Thus to expand a file size, a block must be removed from this list, and 
+  * added to that files mbr_t blocklist.
+  * 
+  * Since there can only be one MBR, the number of entries is restricted
+  * to how many can fit in a single flash page. Hence, this is the 
+  * maximum number of files that can be stored.
+  * 
+  * -- API overview.
+  * Source code is divided logically into two parts:
+  * mbr_*() functions - to access and modify the mbr entries.
+  *                     E.g., to create a new file, change a files size,
+  *                     or append new blocks to the file.
+  *  			These are private methods internal to the class.
+  * 
+  * read/write/seek/unlink - POSIX-style file access functions.
+  *                          These are the functions used to interact with the
+  *                          file system.
+  * 
+  * Example:
+  * @code
+  * MicroBitFile f;
+  * int fd = f.open("myFile.txt", MB_WRITE|MB_CREAT);
+  * if(fd < 0) {
+  *   print("couldn't open a new file");
+  *   exit;
+  * }
+  * if(f.write(fd, "Hello, World!\n",14) != 14) {
+  *   print("error writing!")
+  *   exit
+  * }
+  * f.close(fd);
+  * @endcode
+  * 
+  * -- Notes
+  * - There should exist only one instance of this class.
+  * @todo Reduce the number of mbr_set_filesize() by caching filesize
+  * information in the tinyfs_fd struct.
+  * @todo implement simple wear levelling for file data writes.
+  */
 
-/**
- * @biief MBR entry struct, for each file.
- *
- * The MBR entry struct, for each file in the MBR.
- * This struct is not supposed to be operated on directly,
- * rather via the API in mbr.h
-*/
-typedef struct mbr_t {
-
- char name[FILENAME_LEN]; /**< file name, must be nullterminated */
-
- uint32_t flags; /**< Flags/length field.
-                      MSB is to mark the MBR as busy/free (BUSY = 0),
-                      remaining 30 bits mark the file size. */
-
- uint8_t blocks[(DATA_BLOCK_COUNT)]; /**< List of blocks in the file.
-                                          Initially set to 0xFF
-                                          Must be reset to 0xFF if removed. */
-} mbr;
-
-// Used in the mbr_t.flags field to indicate if the mbr is in use.
-#define MBR_BUSY 0x00000000
+// mbr_t.flags field to indicate if an MBR is free/busy.
 #define MBR_FREE 0x80000000
 
-// Mask with the mbr_t.flags to get the file length.
+// mbr_t.flags field mask to get the file length.
 #define MBR_SIZE_MASK 0x7FFFFFFF
 
 // Used in mbr_t.blocks to indicate if a block is free.
 #define MBR_FREE_BLOCK_MARKER 0x80
+
+// Check if a given MBR is free.
 #define MBR_IS_FREE(mbr) ( (mbr).flags & MBR_FREE)
-
-
-/**
- * @brief struct for each file descriptor
- *
- * Not to be interacted directly by users,
- * which should only be done through the API calls.
- */
-typedef struct tinyfs_fd_t {
- uint8_t flags; /**< read/write/create flags. */
- int32_t seek; /**< current seek position */
- mbr* mbr_entry; /**< pointer to the mbr struct for this file. */
-} tinyfs_fd;
 
 // open() flags.
 #define MB_READ 0x01
@@ -74,257 +88,378 @@ typedef struct tinyfs_fd_t {
 #define MB_SEEK_END 0x02
 #define MB_SEEK_CUR 0x04
 
-
-/**
- * @brief macro to read the file size.
- *
- * @param m a pointer to the MBR struct.
- */
+// Macro to read the file size from an mbr_t pointer.
 #define mbr_get_filesize(m)  (m->flags & MBR_SIZE_MASK)
 
-/*
- * @brief get the enumerated value of the bth block, for MBR m
- *
- * @param m the MBR struct
- * @param b the block index.
- */
+// return the indexed block number from the mbr_t block list.
 #define mbr_get_block(m,b) (m->blocks[b])
 
-/*
- * @brief Obtain pointer to the indexed MBR struct
- *
- * @param index index of the required MBR.
- **/
+// Obtain pointer to the indexed mbr entry.
 #define mbr_by_id(index) (&mbr_loc[index])
 
+/**
+  * @brief MBR entry struct, for each file.
+  * 
+  * The MBR struct is the central source of metadata for each file. It stores:
+  *  - Filename
+  *  - File size
+  *  - List of blocks that constitute the file.
+  *  
+  * The first mbr_t entry is reserved, and stores instead the list of currently
+  * available data blocks (the free block list).
+  * 
+  * Modifications to these structs should be done through mbr_*() methods.
+  */
+typedef struct mbr_t {
+   
+    // Filename, must be null-terminated.
+    char name[FILENAME_LEN];	
+   
+    // Flags/length field.
+    // [31] marks the MBR as free/busy (busy=0)
+    // [0-30] stores the file size.
+    uint32_t flags;	
+   
+    // Ordered list of blocks in the file. Each uint8_t element corresponds to 
+    // a data block:
+    // [7] 	Only used in free block list to mark block as busy/free
+    //		(1 = free, 0 = busy).
+    // [0-6]	Block number.
+    uint8_t blocks[(DATA_BLOCK_COUNT)]; 	
+   				
+} mbr;
 
+/**
+  * @brief struct for each file descriptor
+  *
+  * - read/write/create flags.
+  * - current seek position.
+  * - pointer to the files' mbr struct.
+  */
+typedef struct tinyfs_fd_t {
+    
+    // read/write/creat flags.
+    uint8_t flags;
+   
+    // current seek position.
+    int32_t seek; 
+   
+    // pointer to the files' mbr struct.
+    // A tinyfs_fd_t struct cannot be in use without a valid mbr_entry pointer.
+    mbr* mbr_entry; 
+   
+} tinyfs_fd;
+
+/**
+  * @brief Class definition for the MicroBit File system
+  *
+  * Microbit file system class. Presents a POSIX-like interface consisting of:
+  * - open()
+  * - close()
+  * - read()
+  * - write()
+  * - seek()
+  * - unlink()
+  *
+  * Only a single instance shoud exist at any given time.
+  */
 class MicroBitFile
 {
-private:
-  uint8_t* flash_start = NULL; /**< Location of the start of flash data blocks
-				    *Excluding* MBR entries. */
-
-  int flash_pages = 0; /**< Number of flash pages for data - *excluding*
-			    MBR page*/
-
-  tinyfs_fd fd_table[MAX_FD]; /**< FD table, for open files. */
-
-  MicroBitFlash flash; /**< Instance of MicroBitFlash class, for flash_write/
-			    erase/memset */
-
-  // MBR-specific properties.
-
-  mbr* mbr_free_loc = NULL; /**< MBR struct listing unused blocks */
-
-  mbr* mbr_loc = NULL; /**< MBR table pointer. */
-
-  uint8_t mbr_entries = 0; /** No. of MBR entries (excluding mbr_free_loc */
-
-  /**
-   * @brief Find an MBR entry by name.
-   *
-   * @param filename name of file to search for. Must be null-terminated.
-   * @return pointer to the MBR struct if found, NULL otherwise or on error.
-   */
-  mbr* mbr_by_name(char const * const filename);
+    private:
   
-  /**
-   * @brief Get a pointer to the lowest numbered available MBR entry.
-   *
-   * @return pointer to the MBR if successful, NULL if there are none available.
-   */
-  mbr* mbr_get_free();
-  
-  /**
-   * @brief initialize the mbr struct to the set filename
-   *
-   * Initialize the mbr struct with the given, null-terminated filename.
-   * Ths is used to add a new file to the MBR.
-   * This function also sets the file size to zero, and marks the MBR as busy.
-   *
-   * @param m the mbr struct to use fill.
-   * @param filename is the null terminated filename to use.
-   * @return non-zero on success, zero on error.
-   */
-  int mbr_add(mbr* m, char const * const filename);
-  
-  /**
-   * @brief remove an mbr entry from the MBR.
-   *
-   * Remove an MBR entry from the MBR, thereby removing a file from the system.
-   * This function also frees all of the blocks allocated to m,
-   * back to the list of free blocks.
-   *
-   * @param m the mbr entry/struct to remove.
-   * @return non-zero on success, zero on error.
-   */
-  int mbr_remove(mbr* m);
-  
-  /**
-   * @brief add a new block to an MBR entry
-   *
-   * Add the numbered block to the list of blocks assigned to an MBR entry/file.
-   * This function is used to expand the storage capacity for a file.
-   * @param m the mbr entry/struct to add too.
-   * @param blockNo the numbered block to append to the block list for the entry.
-   * @return non-zero on success, zero on error.
-   */
-  int mbr_add_block(mbr* m, uint8_t blockNo);
-
-  /**
-   * Initialize the flash storage system.
-   *
-   * Initialize the flash storage system, save the location of the flash memory.
-   *
-   * The MBR is always stored in the first page in flash,
-   * subsequent pages are used for data storage.
-   *
-   * @return non-zero on success, zero on error.
-   */
-  int init();
-
-  /**
-   * @brief obtains and marks as busy, an unused block.
-   *
-   * TinyFS implements a list of unused blocks.
-   * This function implements a stack, pop free block, mark as busy and return
-   * its number.
-   *
-   * @return block number on success, -1 on error (out of space).
-   */
-  int mbr_pop_free_block();
+    // The instance of MicroBitFlash - the interface used for all 
+    // flash writes/erasures 
+    MicroBitFlash flash; 
   
   
-  /**
-   * @brief set the filesize of m
-   *
-   * Set, in the MBR, the filesize of the entry, m.
-   * This function is used to mark a file as having extended.
-   * @param m the MBR entry/file to modify
-   * @param filesize the new filesize.
-   * @return non-zero on success, zero on error.
-   */
-  int mbr_set_filesize(mbr* m, uint32_t filesize);
+    // ** MBR-specific members **//
   
-  /**
-   * @brief reset the MBR.
-   *
-   * The MBR must be in an initial state for it to work.
-   * Namely, all of the mbr entries must be set to empty,
-   * and the stack of unused blocks must be populated.
-   *
-   * This function also sets the MAGIC_WORD as the first word in the MBR block,
-   * which is used to determine if the MBR has already been configured.
-   *
-   * This function should be called from the init() function of TinyFS.
-   * @return non-zero on success, zero otherwise.
-   */
-  int mbr_build();
+    // Pointer to the MBR struct listing unused blocks.
+    mbr* mbr_free_loc = NULL; 
+  
+    // Pointer to the MBR table, storing the file mbr entries.
+    mbr* mbr_loc = NULL;
+  
+    // Total number of MBR entries for file data 
+    // (excludes the mbr_fre_loc entry)
+    uint8_t mbr_entries = 0;
+  
+  
+    // ** MicroBitFlash API members (above the MBR). **//
+  
+    // Location of the start of the flash data blocks used for file data.
+    // *Excluding* the flash page reserved for MBR entries.
+    uint8_t* flash_start = NULL; 
+  
+    // Number of flash pages for file data.
+    // *Excluding* the MBR page.
+    int flash_pages = 0; 
+  
+    // The tinyfs_fd table, for open files.
+    tinyfs_fd fd_table[MAX_FD];
 
-public:
-  /*
-   * Constructor.
-   */ 
-  MicroBitFile();
+    // ** MBR-specific methods **/
 
-  /**
-   * @brief initialize the MBR API.
-   *
-   * This function initializes the API for subsequent calls,
-   * particularly storing the flash location, and number of entries.
-   * This function must be called before any other.
-   * @param mbr_location Location in flash of where to store the MBR.
-   * @param mbr_entries The number of entries in the MBR
-   * (hence determining the max no. files).
-   * @return non-zero on success, zero on error.
-  */
-  int mbr_init(void* mbr_location, int mbr_entries);
+    /**
+      * @brief Find an MBR entry by name.
+      *
+      * @param filename name of file to search for. Must be null-terminated.
+      * @return pointer to the MBR struct if found, NULL otherwise or on error.
+      */
+    mbr* mbr_by_name(char const * const filename);
+  
+    /**
+      * @brief Get a pointer to the lowest numbered available MBR entry.
+      *
+      * @return pointer to the MBR if successful, 
+      * 	NULL if there are none available.
+      */
+    mbr* mbr_get_free();
+ 
+    /**
+      * @brief initialize the mbr struct to a new file.
+      *
+      * Initialize the mbr struct with the given, null-terminated filename.
+      * Ths is used to add a new file to the MBR.
+      * This function also sets the file size to zero, 
+      * and marks the MBR as busy.
+      *
+      * @param m the mbr struct to use fill.
+      * @param filename the null terminated filename to use.
+      * @return non-zero on success, zero on error.
+      */
+    int mbr_add(mbr* m, char const * const filename);
+  
+    /**
+      * @brief add a new block to an MBR entry
+      *
+      * Add the numbered block to the list of blocks in an  MBR entry.
+      * This function is used to expand the storage capacity for a file.
+      * 
+      * @param m the mbr entry/struct to add too.
+      * @param blockNo the numbered block to append to the block list of a
+			files' MBR.
+      * @return non-zero on success, zero on error.
+      */
+    int mbr_add_block(mbr* m, uint8_t blockNo);
 
-  /**
-   * Open a new file, and obtain a new file handle to read/write/seek the file.
-   * The flags are:
-   *  - MB_READ : read from the file.
-   *  - MB_WRITE : write to the file.
-   *  - MB_CREAT : create a new file, if it doesn't already exist.
-   *
-   * If a file is opened that doesn't exist, and MB_CREAT isn't passed,
-   * an error is returned, otherwise the file is created.
-   * If the seek pointer is set beyond the current end of the file,
-   * which is then written to, the file is padded with 0x00.
-   *
-   * @todo The same file can only be opened by a single handle at once.
-   *
-   * @param filename name of the file to open, must be null terminated.
-   * @param flags
-   * @return return the file handle, >= 0, or < 0 on error.
-   */
-  int open(char const * const filename, uint8_t flags);
+    /**
+      * @brief reset an MBR entry - remove a file from the MBR table.
+      *
+      * Reset an MBR entry, thereby removing a file from the system.
+      * This function also frees all of the blocks allocated to m,
+      * back to the list of free blocks.
+      *
+      * @param m the mbr entry/struct to remove.
+      * @return non-zero on success, zero on error.
+      */
+    int mbr_remove(mbr* m);
   
-  /**
-   * Close the specified file handle.
-   * File handle resources are then made available for future open() calls.
-   *
-   * @param fd file descriptor - obtained with open().
-   * @return non-zero on success, zero on error.
-   */
-  int close(int fd);
+
+    /**
+      * @brief obtains and marks as busy, an unused block.
+      *
+      * The first MBR entry is reserved, and stores the list of unused blocks.
+      * Thiis function implements a stack, to pop a free block, mark as busy
+      * (subsequent calls will not find the same block), and return its number.
+      *
+      * @return block number on success, -1 on error (out of space).
+      */
+    int mbr_pop_free_block();
   
-  /**
-   * Move the current position of a file handle, to be used for
-   * subsequent read/write calls.
-   *
-   * The offset modifier can be:
-   *  - MB_SEEK_SET set the absolute seek position.
-   *  - MB_SEEK_CUR set the seek position based on the current offset.
-   *  - MB_SEEK_END set the seek position from the end of the file.
-   * E.g. to seek to 2nd-to-last byte, use offset=-1.
-   *
-   * @param fd file handle, obtained with open()
-   * @param offset new offset, can be positive/negative.
-   * @param flags
-   * @return new offset position on success, < 0 on error.
-   */
-  int seek(int fd, int offset, uint8_t flags);
+    /**
+      * @brief set the filesize of an mbr
+      *
+      * Set, in the MBR, the filesize of the entry, m.
+      * 
+      * @param m the MBR entry/file to modify
+      * @param filesize the new filesize.
+      * @return non-zero on success, zero on error.
+      */
+    int mbr_set_filesize(mbr* m, uint32_t filesize);
+
+     /**
+       * @brief initialize the MBR API.
+       *
+       * This function initializes the API for subsequent calls,
+       * particularly storing the flash location, and number of entries.
+       * This function must be called before any other.
+       * 
+       * @param mbr_location Location in flash of where to store the MBR.
+       * @param mbr_entries The number of entries in the MBR
+       *                    (hence determining the max no. files).
+       * @return non-zero on success, zero on error.
+      */
+    int mbr_init(void* mbr_location, int mbr_entries);
+ 
+    /**
+      * @brief reset the MBR.
+      *
+      * The MBR must be in an initial state for it to work.
+      * Namely, all of the mbr entries must be set to empty (0xFF).
+      * and the stack of unused blocks must be populated.
+      *
+      * This function also sets the MAGIC_WORD as the first word in 
+      * the MBR block, used to determine if the MBR has already been 
+      * configured.
+      *
+      * This function should be called from the init() function.
+      * 
+      * @return non-zero on success, zero otherwise.
+      */
+    int mbr_build();
+
+    /**
+      * @brief Initialize the flash storage system
+      *
+      * This method:
+      * - calls mbr_init().
+      * - stores the location of the flash memory.
+      * - calls mbr_build()
+      *
+      * @return non-zero on success, zero on error.
+      */
+    int init();
+
+
+    public:
+
+    /**
+      * Constructor. Calls the necessary init() functions.
+      */ 
+    MicroBitFile();
+
+    /**
+      * Open a new file, and obtain a new file handle (int) to 
+      * read/write/seek the file. The flags are:
+      *  - MB_READ : read from the file.
+      *  - MB_WRITE : write to the file.
+      *  - MB_CREAT : create a new file, if it doesn't already exist.
+      *
+      * If a file is opened that doesn't exist, and MB_CREAT isn't passed,
+      * an error is returned, otherwise the file is created.
+      * If the seek pointer is set beyond the current end of the file,
+      * which is then written to, the file is padded with 0x00.
+      *
+      * @todo The same file can only be opened by a single handle at once.
+      * @todo Add MB_APPEND flag.
+      *
+      * @param filename name of the file to open, must be null terminated.
+      * @param flags
+      * @return return the file handle, >= 0, or < 0 on error.
+      * 
+      * Example:
+      * @code
+      * MicroBitFile f();
+      * int fd = f.open("test.txt", MB_WRITE|MB_CREAT);
+      * if(fd<0) 
+      *    print("file open error");
+      * @endcode
+      */
+    int open(char const * const filename, uint8_t flags);
   
-  /**
-   * Write data to the file.
-   *
-   * Write from buffer, len bytes to the current seek position.
-   * On each invocation to write, the seek position of the file handle
-   * is incremented atomically, by the number of bytes returned.
-   *
-   * @param fd File handle
-   * @param buffer the buffer from which to write data
-   * @param len number of bytes to write
-   * @return number of bytes written on success, < 0 on error.
-   *
-   */
-  int write(int fd, uint8_t* buffer, int len);
+    /**
+      * Close the specified file handle.
+      * File handle resources are then made available for future open() calls.
+      *
+      * @param fd file descriptor - obtained with open().
+      * @return non-zero on success, zero on error.
+      *
+      * Example:
+      * @code
+      * MicroBitFile f();
+      * int fd = f.open("test.txt", MB_READ);
+      * if(!f.close(fd))
+      *    print("error closing file.");
+      * @endcode
+      */
+    int close(int fd);
   
-  /**
-   * Read data from the file.
-   *
-   * Read len bytes from the current seek position in the file, into the buffer.
-   * On each invocation to read, the seek position of the file handle
-   * is incremented atomically, by the number of bytes returned.
-   *
-   * @param fd File handle, obtained with open()
-   * @param buffer to store data
-   * @param len number of bytes to read
-   * @return number of bytes read on success, < 0 on error.
-   */
-  int read(int fd, uint8_t* buffer, int len);
+    /**
+      * Move the current position of a file handle, to be used for
+      * subsequent read/write calls.
+      *
+      * The offset modifier can be:
+      *  - MB_SEEK_SET set the absolute seek position.
+      *  - MB_SEEK_CUR set the seek position based on the current offset.
+      *  - MB_SEEK_END set the seek position from the end of the file.
+      * E.g. to seek to 2nd-to-last byte, use offset=-1.
+      *
+      * @param fd file handle, obtained with open()
+      * @param offset new offset, can be positive/negative.
+      * @param flags
+      * @return new offset position on success, < 0 on error.
+      * 
+      * Example:
+      * @code
+      * MicroBitFile f;
+      * int fd = f.open("test.txt", MB_READ);
+      * f.seek(fd, -100, MB_SEEK_END); //100 bytes before end of file.
+      * @endcode
+      */
+    int seek(int fd, int offset, uint8_t flags);
   
-  /**
-   * Remove a file from the system, and free allocated assets
-   * (including assigned blocks which are returned for use by other files).
-   *
-   * @todo the file must not already have an open file handle.
-   *
-   * @param filename null-terminated name of the file to remove.
-   * @return non-zero on success, zero on error
-   */
-  int unlink(char const * const filename);
+    /**
+      * Write data to the file.
+      *
+      * Write from buffer, len bytes to the current seek position.
+      * On each invocation to write, the seek position of the file handle
+      * is incremented atomically, by the number of bytes returned.
+      *
+      * @param fd File handle
+      * @param buffer the buffer from which to write data
+      * @param len number of bytes to write
+      * @return number of bytes written on success, < 0 on error.
+      *
+      * Example:
+      * @code
+      * MicroBitFile f();
+      * int fd = f.open("test.txt", MB_WRITE);
+      * if(f.write(fd, "hello!", 7) != 7)
+           print("error writing");
+      * @endcode
+      */
+    int write(int fd, uint8_t* buffer, int len);
+  
+    /**
+      * Read data from the file.
+      *
+      * Read len bytes from the current seek position in the file, into the buffer.
+      * On each invocation to read, the seek position of the file handle
+      * is incremented atomically, by the number of bytes returned.
+      *
+      * @param fd File handle, obtained with open()
+      * @param buffer to store data
+      * @param len number of bytes to read
+      * @return number of bytes read on success, < 0 on error.
+      *
+      * Example:
+      * @code
+      * MicroBitFile f;
+      * int fd = f.open("read.txt", MB_READ);
+      * if(f.read(fd, buffer, 100) != 100) 
+      *    print("read error");
+      * @endcode
+      */
+    int read(int fd, uint8_t* buffer, int len);
+  
+    /**
+      * Remove a file from the system, and free allocated assets
+      * (including assigned blocks which are returned for use by other files).
+      *
+      * @todo the file must not already have an open file handle.
+      *
+      * @param filename null-terminated name of the file to remove.
+      * @return non-zero on success, zero on error
+      *
+      * Example:
+      * @code
+      * MicroBitFile f;
+      * if(!f.unlink("file.txt"))
+      *     print("file could not be deleted")
+      * @endcode
+      */
+    int unlink(char const * const filename);
 };
 
 #endif

--- a/inc/MicroBitFile.h
+++ b/inc/MicroBitFile.h
@@ -1,6 +1,6 @@
 #ifndef MICROBIT_FILE_H_
 #define MICROBIT_FILE_H_
-#include "tinyfs_config.h"
+#include "MicroBitFile_config.h"
 #include "MicroBitFlash.h"
 #include "MicroBit.h"
 

--- a/inc/MicroBitFile.h
+++ b/inc/MicroBitFile.h
@@ -67,6 +67,7 @@
 
 // mbr_t.flags field to indicate if an MBR is free/busy.
 #define MBR_FREE 0x80000000
+#define MBR_BUSY 0x00000000
 
 // mbr_t.flags field mask to get the file length.
 #define MBR_SIZE_MASK 0x7FFFFFFF
@@ -76,6 +77,8 @@
 
 // Check if a given MBR is free.
 #define MBR_IS_FREE(mbr) ( (mbr).flags & MBR_FREE)
+
+
 
 // open() flags.
 #define MB_READ 0x01
@@ -97,9 +100,12 @@
 // Obtain pointer to the indexed mbr entry.
 #define mbr_by_id(index) (&mbr_loc[index])
 
-// Check if init() has been called 
-#define FS_INITIALIZED() (flash_start != NULL)
-#define MBR_INITIALIZED() (mbr_loc != NULL)
+// Test if init()/mbr_init have been called.
+#define FS_INITIALIZED() (this->flash_start != NULL)
+#define MBR_INITIALIZED() (this->mbr_loc != NULL)
+
+// Check if a mbr pointer is within table.
+#define MBR_PTR_VALID(p) ( (p >= this->mbr_loc) && (p-this->mbr_loc)<=(this->mbr_entries-1) )
 
 /**
   * @brief MBR entry struct, for each file.

--- a/inc/MicroBitFile.h
+++ b/inc/MicroBitFile.h
@@ -97,6 +97,10 @@
 // Obtain pointer to the indexed mbr entry.
 #define mbr_by_id(index) (&mbr_loc[index])
 
+// Check if init() has been called 
+#define FS_INITIALIZED() (flash_start != NULL)
+#define MBR_INITIALIZED() (mbr_loc != NULL)
+
 /**
   * @brief MBR entry struct, for each file.
   * 

--- a/inc/MicroBitFile.h
+++ b/inc/MicroBitFile.h
@@ -1,0 +1,330 @@
+#ifndef MICROBIT_FILE_H_
+#define MICROBIT_FILE_H_
+#include "tinyfs_config.h"
+#include "MicroBitFlash.h"
+#include "MicroBit.h"
+
+/**
+ * @file MicroBitFile.h
+ * @author Alex King
+ * @date 6 Mar 2016
+ *
+ * @brief API for POSIX-like file system interface: open/close/read/write.
+ *
+ * Class is divided into two parts: public POSIX methods:
+ * open/close/read/write/unlink
+ *
+ * And private Master Boot Record methods, to 
+ * access and change entries in the MBR page - which stores file 
+ * state information.
+ */
+
+/**
+ * @biief MBR entry struct, for each file.
+ *
+ * The MBR entry struct, for each file in the MBR.
+ * This struct is not supposed to be operated on directly,
+ * rather via the API in mbr.h
+*/
+typedef struct mbr_t {
+
+ char name[FILENAME_LEN]; /**< file name, must be nullterminated */
+
+ uint32_t flags; /**< Flags/length field.
+                      MSB is to mark the MBR as busy/free (BUSY = 0),
+                      remaining 30 bits mark the file size. */
+
+ uint8_t blocks[(DATA_BLOCK_COUNT)]; /**< List of blocks in the file.
+                                          Initially set to 0xFF
+                                          Must be reset to 0xFF if removed. */
+} mbr;
+
+// Used in the mbr_t.flags field to indicate if the mbr is in use.
+#define MBR_BUSY 0x00000000
+#define MBR_FREE 0x80000000
+
+// Mask with the mbr_t.flags to get the file length.
+#define MBR_SIZE_MASK 0x7FFFFFFF
+
+// Used in mbr_t.blocks to indicate if a block is free.
+#define MBR_FREE_BLOCK_MARKER 0x80
+#define MBR_IS_FREE(mbr) ( (mbr).flags & MBR_FREE)
+
+
+/**
+ * @brief struct for each file descriptor
+ *
+ * Not to be interacted directly by users,
+ * which should only be done through the API calls.
+ */
+typedef struct tinyfs_fd_t {
+ uint8_t flags; /**< read/write/create flags. */
+ int32_t seek; /**< current seek position */
+ mbr* mbr_entry; /**< pointer to the mbr struct for this file. */
+} tinyfs_fd;
+
+// open() flags.
+#define MB_READ 0x01
+#define MB_WRITE 0x02
+#define MB_CREAT 0x04
+#define MB_FD_BUSY 0x10
+
+// seek() flags.
+#define MB_SEEK_SET 0x01
+#define MB_SEEK_END 0x02
+#define MB_SEEK_CUR 0x04
+
+
+/**
+ * @brief macro to read the file size.
+ *
+ * @param m a pointer to the MBR struct.
+ */
+#define mbr_get_filesize(m)  (m->flags & MBR_SIZE_MASK)
+
+/*
+ * @brief get the enumerated value of the bth block, for MBR m
+ *
+ * @param m the MBR struct
+ * @param b the block index.
+ */
+#define mbr_get_block(m,b) (m->blocks[b])
+
+/*
+ * @brief Obtain pointer to the indexed MBR struct
+ *
+ * @param index index of the required MBR.
+ **/
+#define mbr_by_id(index) (&mbr_loc[index])
+
+
+class MicroBitFile
+{
+private:
+  uint8_t* flash_start = NULL; /**< Location of the start of flash data blocks
+				    *Excluding* MBR entries. */
+
+  int flash_pages = 0; /**< Number of flash pages for data - *excluding*
+			    MBR page*/
+
+  tinyfs_fd fd_table[MAX_FD]; /**< FD table, for open files. */
+
+  MicroBitFlash flash; /**< Instance of MicroBitFlash class, for flash_write/
+			    erase/memset */
+
+  // MBR-specific properties.
+
+  mbr* mbr_free_loc = NULL; /**< MBR struct listing unused blocks */
+
+  mbr* mbr_loc = NULL; /**< MBR table pointer. */
+
+  uint8_t mbr_entries = 0; /** No. of MBR entries (excluding mbr_free_loc */
+
+  /**
+   * @brief Find an MBR entry by name.
+   *
+   * @param filename name of file to search for. Must be null-terminated.
+   * @return pointer to the MBR struct if found, NULL otherwise or on error.
+   */
+  mbr* mbr_by_name(char const * const filename);
+  
+  /**
+   * @brief Get a pointer to the lowest numbered available MBR entry.
+   *
+   * @return pointer to the MBR if successful, NULL if there are none available.
+   */
+  mbr* mbr_get_free();
+  
+  /**
+   * @brief initialize the mbr struct to the set filename
+   *
+   * Initialize the mbr struct with the given, null-terminated filename.
+   * Ths is used to add a new file to the MBR.
+   * This function also sets the file size to zero, and marks the MBR as busy.
+   *
+   * @param m the mbr struct to use fill.
+   * @param filename is the null terminated filename to use.
+   * @return non-zero on success, zero on error.
+   */
+  int mbr_add(mbr* m, char const * const filename);
+  
+  /**
+   * @brief remove an mbr entry from the MBR.
+   *
+   * Remove an MBR entry from the MBR, thereby removing a file from the system.
+   * This function also frees all of the blocks allocated to m,
+   * back to the list of free blocks.
+   *
+   * @param m the mbr entry/struct to remove.
+   * @return non-zero on success, zero on error.
+   */
+  int mbr_remove(mbr* m);
+  
+  /**
+   * @brief add a new block to an MBR entry
+   *
+   * Add the numbered block to the list of blocks assigned to an MBR entry/file.
+   * This function is used to expand the storage capacity for a file.
+   * @param m the mbr entry/struct to add too.
+   * @param blockNo the numbered block to append to the block list for the entry.
+   * @return non-zero on success, zero on error.
+   */
+  int mbr_add_block(mbr* m, uint8_t blockNo);
+
+  /**
+   * Initialize the flash storage system.
+   *
+   * Initialize the flash storage system, save the location of the flash memory.
+   *
+   * The MBR is always stored in the first page in flash,
+   * subsequent pages are used for data storage.
+   *
+   * @return non-zero on success, zero on error.
+   */
+  int init();
+
+  /**
+   * @brief obtains and marks as busy, an unused block.
+   *
+   * TinyFS implements a list of unused blocks.
+   * This function implements a stack, pop free block, mark as busy and return
+   * its number.
+   *
+   * @return block number on success, -1 on error (out of space).
+   */
+  int mbr_pop_free_block();
+  
+  
+  /**
+   * @brief set the filesize of m
+   *
+   * Set, in the MBR, the filesize of the entry, m.
+   * This function is used to mark a file as having extended.
+   * @param m the MBR entry/file to modify
+   * @param filesize the new filesize.
+   * @return non-zero on success, zero on error.
+   */
+  int mbr_set_filesize(mbr* m, uint32_t filesize);
+  
+  /**
+   * @brief reset the MBR.
+   *
+   * The MBR must be in an initial state for it to work.
+   * Namely, all of the mbr entries must be set to empty,
+   * and the stack of unused blocks must be populated.
+   *
+   * This function also sets the MAGIC_WORD as the first word in the MBR block,
+   * which is used to determine if the MBR has already been configured.
+   *
+   * This function should be called from the init() function of TinyFS.
+   * @return non-zero on success, zero otherwise.
+   */
+  int mbr_build();
+
+public:
+  /*
+   * Constructor.
+   */ 
+  MicroBitFile();
+
+  /**
+   * @brief initialize the MBR API.
+   *
+   * This function initializes the API for subsequent calls,
+   * particularly storing the flash location, and number of entries.
+   * This function must be called before any other.
+   * @param mbr_location Location in flash of where to store the MBR.
+   * @param mbr_entries The number of entries in the MBR
+   * (hence determining the max no. files).
+   * @return non-zero on success, zero on error.
+  */
+  int mbr_init(void* mbr_location, int mbr_entries);
+
+  /**
+   * Open a new file, and obtain a new file handle to read/write/seek the file.
+   * The flags are:
+   *  - MB_READ : read from the file.
+   *  - MB_WRITE : write to the file.
+   *  - MB_CREAT : create a new file, if it doesn't already exist.
+   *
+   * If a file is opened that doesn't exist, and MB_CREAT isn't passed,
+   * an error is returned, otherwise the file is created.
+   * If the seek pointer is set beyond the current end of the file,
+   * which is then written to, the file is padded with 0x00.
+   *
+   * @todo The same file can only be opened by a single handle at once.
+   *
+   * @param filename name of the file to open, must be null terminated.
+   * @param flags
+   * @return return the file handle, >= 0, or < 0 on error.
+   */
+  int open(char const * const filename, uint8_t flags);
+  
+  /**
+   * Close the specified file handle.
+   * File handle resources are then made available for future open() calls.
+   *
+   * @param fd file descriptor - obtained with open().
+   * @return non-zero on success, zero on error.
+   */
+  int close(int fd);
+  
+  /**
+   * Move the current position of a file handle, to be used for
+   * subsequent read/write calls.
+   *
+   * The offset modifier can be:
+   *  - MB_SEEK_SET set the absolute seek position.
+   *  - MB_SEEK_CUR set the seek position based on the current offset.
+   *  - MB_SEEK_END set the seek position from the end of the file.
+   * E.g. to seek to 2nd-to-last byte, use offset=-1.
+   *
+   * @param fd file handle, obtained with open()
+   * @param offset new offset, can be positive/negative.
+   * @param flags
+   * @return new offset position on success, < 0 on error.
+   */
+  int seek(int fd, int offset, uint8_t flags);
+  
+  /**
+   * Write data to the file.
+   *
+   * Write from buffer, len bytes to the current seek position.
+   * On each invocation to write, the seek position of the file handle
+   * is incremented atomically, by the number of bytes returned.
+   *
+   * @param fd File handle
+   * @param buffer the buffer from which to write data
+   * @param len number of bytes to write
+   * @return number of bytes written on success, < 0 on error.
+   *
+   */
+  int write(int fd, uint8_t* buffer, int len);
+  
+  /**
+   * Read data from the file.
+   *
+   * Read len bytes from the current seek position in the file, into the buffer.
+   * On each invocation to read, the seek position of the file handle
+   * is incremented atomically, by the number of bytes returned.
+   *
+   * @param fd File handle, obtained with open()
+   * @param buffer to store data
+   * @param len number of bytes to read
+   * @return number of bytes read on success, < 0 on error.
+   */
+  int read(int fd, uint8_t* buffer, int len);
+  
+  /**
+   * Remove a file from the system, and free allocated assets
+   * (including assigned blocks which are returned for use by other files).
+   *
+   * @todo the file must not already have an open file handle.
+   *
+   * @param filename null-terminated name of the file to remove.
+   * @return non-zero on success, zero on error
+   */
+  int unlink(char const * const filename);
+};
+
+#endif

--- a/inc/MicroBitFile_config.h
+++ b/inc/MicroBitFile_config.h
@@ -27,31 +27,31 @@
 
 #define MAX_FILENAME_LEN FILENAME_LEN-1
 
-// MAGIC word at the beginning of the flash region/MBR table. Not really necessary to configure/change.
+// MAGIC word at the beginning of the flash region/FT table. Not really necessary to configure/change.
 #define MAGIC_WORD 0xA3E8F1C7
 
 // The number of flash pages available to the file system.
-// The total number available for flash storage is 1 less: used for the MBR table.
+// The total number available for flash storage is 1 less: used for the FT table.
 // This can be no greater than (2^7-1 = 127), as block numbers are stored in uint8_t's.
 #define DATA_BLOCK_COUNT 40
 
-// Number of MBR entries in the MBR table. Since this is a flat file system, without directories, this determines the maximum number of files the system can hold.
-// The number of MBR entries includes the free mbr list. 
-// Therefore, the maximum number of files will actually be NO_MBR_ENTRIES-1.
-// The MBR must fit in a single page.
-#define NO_MBR_ENTRIES 10
+// Number of FT entries in the FT table. Since this is a flat file system, without directories, this determines the maximum number of files the system can hold.
+// The number of FT entries includes the free mbr list. 
+// Therefore, the maximum number of files will actually be NO_FT_ENTRIES-1.
+// The FT must fit in a single page.
+#define NO_FT_ENTRIES 10
 
 /** --  Pre-compiler validation checks -- **/
 #if ( ((FLASH_START % PAGE_SIZE) != 0) && !TESTING )
 #error FLASH_START must be on a page boundary.
 #endif
 
-#if NO_MBR_ENTRIES < 2
-#error NO_MBR_ENTRIES must be at least 2.
+#if NO_FT_ENTRIES < 2
+#error NO_FT_ENTRIES must be at least 2.
 #endif
 
-#if ( (FILENAME_LEN + DATA_BLOCK_COUNT + 4 ) * NO_MBR_ENTRIES ) > PAGE_SIZE
-#error NO_MBR_ENTRIES is too large, cannot fit in a single page.
+#if ( (FILENAME_LEN + DATA_BLOCK_COUNT + 4 ) * NO_FT_ENTRIES ) > PAGE_SIZE
+#error NO_FT_ENTRIES is too large, cannot fit in a single page.
 #endif
 
 #if DATA_BLOCK_COUNT > 127

--- a/inc/MicroBitFile_config.h
+++ b/inc/MicroBitFile_config.h
@@ -1,0 +1,61 @@
+#ifndef _TINYFS__CONFIG_
+#define _TINYFS__CONFIG_ 1
+
+// Used for TESTING, set a custom (e.g. obtained with malloc) flash start pointer, and ignore PAGE_BOUNDARY checks.
+#ifndef TESTING
+#define TESTING 0
+#endif
+
+// Memory address of the start of flash.
+// Must be aligned on a page boundary.
+#define FLASH_START 0x2F000
+#ifndef FLASH_START
+#warning FLASH_START not set, using default 0x3000
+#define FLASH_START 0x3000
+#endif
+
+// Size of a page in flash.
+#define PAGE_SIZE 1024
+
+// Maximum number of open FD's.
+// Reducing this number reduces RAM footprint.
+#define MAX_FD 3
+
+// Maximum filename length. 
+// This includes the null terminator.
+#define FILENAME_LEN 14
+
+#define MAX_FILENAME_LEN FILENAME_LEN-1
+
+// MAGIC word at the beginning of the flash region/MBR table. Not really necessary to configure/change.
+#define MAGIC_WORD 0xA3E8F1C7
+
+// The number of flash pages available to the file system.
+// The total number available for flash storage is 1 less: used for the MBR table.
+// This can be no greater than (2^7-1 = 127), as block numbers are stored in uint8_t's.
+#define DATA_BLOCK_COUNT 60
+
+// Number of MBR entries in the MBR table. Since this is a flat file system, without directories, this determines the maximum number of files the system can hold.
+// The number of MBR entries includes the free mbr list. 
+// Therefore, the maximum number of files will actually be NO_MBR_ENTRIES-1.
+// The MBR must fit in a single page.
+#define NO_MBR_ENTRIES 10
+
+/** --  Pre-compiler validation checks -- **/
+#if ( ((FLASH_START % PAGE_SIZE) != 0) && !TESTING )
+#error FLASH_START must be on a page boundary.
+#endif
+
+#if NO_MBR_ENTRIES < 2
+#error NO_MBR_ENTRIES must be at least 2.
+#endif
+
+#if ( (FILENAME_LEN + DATA_BLOCK_COUNT + 4 ) * NO_MBR_ENTRIES ) > PAGE_SIZE
+#error NO_MBR_ENTRIES is too large, cannot fit in a single page.
+#endif
+
+#if DATA_BLOCK_COUNT > 127
+#error DATA_BLOCK_COUNT cannot be greater than (2^7-1 = 127).
+#endif
+
+#endif

--- a/inc/MicroBitFile_config.h
+++ b/inc/MicroBitFile_config.h
@@ -33,7 +33,7 @@
 // The number of flash pages available to the file system.
 // The total number available for flash storage is 1 less: used for the MBR table.
 // This can be no greater than (2^7-1 = 127), as block numbers are stored in uint8_t's.
-#define DATA_BLOCK_COUNT 60
+#define DATA_BLOCK_COUNT 40
 
 // Number of MBR entries in the MBR table. Since this is a flat file system, without directories, this determines the maximum number of files the system can hold.
 // The number of MBR entries includes the free mbr list. 

--- a/inc/MicroBitFlash.h
+++ b/inc/MicroBitFlash.h
@@ -6,93 +6,117 @@
 #define PAGE_SIZE 1024
 
 typedef enum flash_mode_t {
- WR_WRITE,
- WR_MEMSET
+    WR_WRITE,
+    WR_MEMSET
 } flash_mode;
 
 class MicroBitFlash
 {
-private:
-  uint32_t* flash_start; /**< Start of flash reserved for this class */
+    private:
+    // Address of the first word in flash memory we can write to.
+    uint32_t* flash_start; 
 
-  /*
-   * Erase an entire page.
-   * @param page_address address of first word of page.
-   */
-  void erase_page(uint32_t* page_address);
+    /**
+      * Erase an entire page.
+      * @param page_address address of first word of page.
+      */
+    void erase_page(uint32_t* page_address);
 
-  /*
-   * Write to flash memory, assuming that a write is valid
-   * (using need_erase).
-   * @param page_address address of memory to write to. 
-   * 	Must be word aligned.
-   * @param buffer address to write from, must be word-aligned.
-   * @param len number of uint32_t words to write.
-   */
-  void flash_burn(uint32_t* page_address, uint32_t* buffer, int len);
+    /**
+      * Write to flash memory, assuming that a write is valid
+      * (using need_erase).
+      * 
+      * @param page_address address of memory to write to. 
+      * 	Must be word aligned.
+      * @param buffer address to write from, must be word-aligned.
+      * @param len number of uint32_t words to write.
+      */
+    void flash_burn(uint32_t* page_address, uint32_t* buffer, int len);
 
-  /*
-   * Write to address in flash.
-   * Ensures that the data is written correctly, erasing the page if necessary.
-   * In which case, non-addressed writes are preserved by saving to the 
-   * scratch page.
-   * @param address in flash to write to  
-   * @param from_buffer address to write data from
-   * @param write_byte if writing the same byte to add addressed bytes
-   * @param len number of bytes to write to/copy to
-   * @param m mode to use this function, memset/memcpy.
-   * @return non-zero on success, zero on error.
-   */
-  int flash_write_mem(uint8_t* address, uint8_t* from_buffer,
-                      uint8_t write_byte, int len, flash_mode m);
+    /**
+      * Write to address in flash, implementing either flash_write (copy
+      * data from buffer), or flash_memset (set all bytes in flash to 
+      * provided constant.
+      *
+      * Function ensures that data is written correctly:
+      * - erase page if necessary (using need_erase)
+      * - preserve non-target flash by copying to scratch page.
+      * 
+      * @param address in flash to write to  
+      * @param from_buffer address to write data from
+      * @param write_byte if writing the same byte to add addressed bytes
+      * @param len number of bytes to write to/copy to
+      * @param m mode to use this function, memset/memcpy.
+      * @return non-zero on success, zero on error.
+      */
+    int flash_write_mem(uint8_t* address, uint8_t* from_buffer,
+                        uint8_t write_byte, int len, flash_mode m);
 
-  /*
-   * Check if an erase is required to write to a region in flash memory.
-   * This is determined if, for any byte:
-   * ~O & N != 0x00
-   * Where O=Original byte, N = New byte.
-   *
-   * @param source to write from
-   * @param flash_address to write to
-   * @param len number of uint8_t to check.
-   * @return non-zero if erase required, zero otherwise.
-   */
-  int need_erase(uint8_t* source, uint8_t* flash_addr, int len);
+    /**
+      * Check if an erase is required to write to a region in flash memory.
+      * This is determined if, for any byte:
+      * ~O & N != 0x00
+      * Where O=Original byte, N = New byte.
+      *
+      * @param source to write from
+      * @param flash_address to write to
+      * @param len number of uint8_t to check.
+      * @return non-zero if erase required, zero otherwise.
+      */
+    int need_erase(uint8_t* source, uint8_t* flash_addr, int len);
  
-public:
+    public:
+    /**
+      * Default constructor.
+      */
+    MicroBitFlash();
 
-  /*
-   * Default constructor.
-   */
-  MicroBitFlash();
+    /**
+      * Writes the given number of bytes to the address in flash specified.
+      * Neither address nor buffer need be word-aligned.
+      * @param address location in flash to write to.
+      * @param buffer location in memory to write from. 
+      * @length number of bytes to burn
+      * @return non-zero on sucess, zero on error.
+      * 
+      * Example:
+      * @code
+      * MicroBitFlash flash();
+      * uint32_t word = 0x01;
+      * flash.flash_write((uint8_t*)0x38000, &word, sizeof(word))
+      * @endcode
+      */
+    int flash_write(uint8_t* address, uint8_t* buffer, int length);
 
-  /*
-   * Writes the given number of bytes to the address in flash specified.
-   * Neither address nor buffer need be word-aligned.
-   * @param address location in flash to write to.
-   * @param buffer location in memory to write from. 
-   * @length number of bytes to burn
-   * @return non-zero on sucess, zero on error.
-   */
-  int flash_write(uint8_t* address, uint8_t* buffer, int length);
+    /**
+      * Set bytes in [address, address+length] to byte.
+      * Neither address nor buffer need be word-aligned.
+      * @param address to write to
+      * @param byte byte to burn to flash
+      * @param length number of bytes to write to.
+      * @return non-zero on success, zero on error.
+      * 
+      * Example:
+      * @code
+      * MicroBitFlash flash();
+      * flash.flash_memset((uint8_t*)0x38000, 0x66, 12); //12 bytes to 0x66.
+      * @endcode
+      */
+    int flash_memset(uint8_t* address, uint8_t byte, int length);
 
-  /*
-   * Set bytes in [address, address+length] to byte.
-   * Neither address nor buffer need be word-aligned.
-   * @param address to write to
-   * @param byte byte to burn to flash
-   * @param length number of bytes to write to.
-   * @return non-zero on success, zero on error.
-   */
-  int flash_memset(uint8_t* address, uint8_t byte, int length);
-
-  /*
-   * Erase bytes in memory, from set address.
-   * @param address to erase bytes from (needn't be word-aligned.
-   * @param length number of bytes to erase (set to 0xFF).
-   * @return non-zero on success, zero on error.  
-   */
-  int flash_erase_mem(uint8_t* address, int length);
+    /**
+      * Erase bytes in memory, from set address.
+      * @param address to erase bytes from (needn't be word-aligned.
+      * @param length number of bytes to erase (set to 0xFF).
+      * @return non-zero on success, zero on error.  
+      * 
+      * Example:
+      * @code
+      * MicroBitFlash flash();
+      * flash.flash_erase((uint8_t*)0x38000, 10240); //erase a flash page.
+      * @endcode
+      */
+    int flash_erase_mem(uint8_t* address, int length);
 
 };
 

--- a/inc/MicroBitFlash.h
+++ b/inc/MicroBitFlash.h
@@ -5,7 +5,8 @@
 #define SCRATCH_PAGE_ADDR 0x2EC00
 #define PAGE_SIZE 1024
 
-typedef enum flash_mode_t {
+typedef enum flash_mode_t 
+{
     WR_WRITE,
     WR_MEMSET
 } flash_mode;
@@ -13,8 +14,6 @@ typedef enum flash_mode_t {
 class MicroBitFlash
 {
     private:
-    // Address of the first word in flash memory we can write to.
-    uint32_t* flash_start; 
 
     /**
       * Erase an entire page.

--- a/inc/MicroBitFlash.h
+++ b/inc/MicroBitFlash.h
@@ -1,0 +1,99 @@
+#ifndef MICROBIT_FLASH_H_
+#define MICROBIT_FLASH_H_
+#include "MicroBit.h"
+
+#define SCRATCH_PAGE_ADDR 0x2EC00
+#define PAGE_SIZE 1024
+
+typedef enum flash_mode_t {
+ WR_WRITE,
+ WR_MEMSET
+} flash_mode;
+
+class MicroBitFlash
+{
+private:
+  uint32_t* flash_start; /**< Start of flash reserved for this class */
+
+  /*
+   * Erase an entire page.
+   * @param page_address address of first word of page.
+   */
+  void erase_page(uint32_t* page_address);
+
+  /*
+   * Write to flash memory, assuming that a write is valid
+   * (using need_erase).
+   * @param page_address address of memory to write to. 
+   * 	Must be word aligned.
+   * @param buffer address to write from, must be word-aligned.
+   * @param len number of uint32_t words to write.
+   */
+  void flash_burn(uint32_t* page_address, uint32_t* buffer, int len);
+
+  /*
+   * Write to address in flash.
+   * Ensures that the data is written correctly, erasing the page if necessary.
+   * In which case, non-addressed writes are preserved by saving to the 
+   * scratch page.
+   * @param address in flash to write to  
+   * @param from_buffer address to write data from
+   * @param write_byte if writing the same byte to add addressed bytes
+   * @param len number of bytes to write to/copy to
+   * @param m mode to use this function, memset/memcpy.
+   * @return non-zero on success, zero on error.
+   */
+  int flash_write_mem(uint8_t* address, uint8_t* from_buffer,
+                      uint8_t write_byte, int len, flash_mode m);
+
+  /*
+   * Check if an erase is required to write to a region in flash memory.
+   * This is determined if, for any byte:
+   * ~O & N != 0x00
+   * Where O=Original byte, N = New byte.
+   *
+   * @param source to write from
+   * @param flash_address to write to
+   * @param len number of uint8_t to check.
+   * @return non-zero if erase required, zero otherwise.
+   */
+  int need_erase(uint8_t* source, uint8_t* flash_addr, int len);
+ 
+public:
+
+  /*
+   * Default constructor.
+   */
+  MicroBitFlash();
+
+  /*
+   * Writes the given number of bytes to the address in flash specified.
+   * Neither address nor buffer need be word-aligned.
+   * @param address location in flash to write to.
+   * @param buffer location in memory to write from. 
+   * @length number of bytes to burn
+   * @return non-zero on sucess, zero on error.
+   */
+  int flash_write(uint8_t* address, uint8_t* buffer, int length);
+
+  /*
+   * Set bytes in [address, address+length] to byte.
+   * Neither address nor buffer need be word-aligned.
+   * @param address to write to
+   * @param byte byte to burn to flash
+   * @param length number of bytes to write to.
+   * @return non-zero on success, zero on error.
+   */
+  int flash_memset(uint8_t* address, uint8_t byte, int length);
+
+  /*
+   * Erase bytes in memory, from set address.
+   * @param address to erase bytes from (needn't be word-aligned.
+   * @param length number of bytes to erase (set to 0xFF).
+   * @return non-zero on success, zero on error.  
+   */
+  int flash_erase_mem(uint8_t* address, int length);
+
+};
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -46,6 +46,8 @@ set(YOTTA_AUTO_MICROBIT-DAL_CPP_FILES
     "ble-services/MicroBitRadio.cpp"
     "ble-services/MicroBitRadioDatagram.cpp"
     "ble-services/MicroBitRadioEvent.cpp"
+    "MicroBitFile.cpp"
+    "MicroBitFlash.cpp"
 )
 
 execute_process(WORKING_DIRECTORY "../../yotta_modules/${PROJECT_NAME}" COMMAND "git" "log" "--pretty=format:%h" "-n" "1" OUTPUT_VARIABLE git_hash)

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -6,58 +6,51 @@
 
 #define MIN(a,b) ((a)<(b)?(a):(b))
 
-#define DEBUG 0
-#if DEBUG
-#define PRINTF(...) uBit.serial.printf(__VA_ARGS__)
-#else
-#define PRINTF(...)
-#endif
-
 /**
-  * @brief Find an MBR entry by name.
+  * @brief Find an FT entry by name.
   *
   * @param filename name of file to search for. Must be null-terminated.
-  * @return pointer to the MBR struct if found, NULL otherwise or on error.
+  * @return pointer to the FT struct if found, NULL otherwise or on error.
   */
-mbr* MicroBitFile::mbr_by_name(char const * const filename) {
-   
-    for(int i=0;i<this->mbr_entries;++i) {
-        if(strcmp(filename, this->mbr_loc[i].name) == 0) {
-            return &this->mbr_loc[i];
+FileTableEntry* MicroBitFile::ft_by_name(char const * filename) 
+{
+    for(int i=0;i<this->ft_entries;++i) {
+        if(strcmp(filename, this->ft_loc[i].name) == 0) {
+            return &this->ft_loc[i];
         }
     }
     return NULL;
 }
 
 /**
-  * @brief Get a pointer to the lowest numbered available MBR entry.
+  * @brief Get a pointer to the lowest numbered available FT entry.
   *
-  * @return pointer to the MBR if successful,
-  *         NULL if there are none available.
+  * @return pointer to the FT if successful,
+  *     NULL if there are none available.
   */
-mbr* MicroBitFile::mbr_get_free() {
-   
-    for(int i=0;i<this->mbr_entries;++i) {
-        if(MBR_IS_FREE(this->mbr_loc[i])) return &this->mbr_loc[i];
+FileTableEntry* MicroBitFile::ft_get_free() 
+{
+    for(int i=0;i<this->ft_entries;++i) {
+        if(FT_IS_FREE(this->ft_loc[i])) return &this->ft_loc[i];
     }
     return NULL;
 }
 
 /**
-  * @brief initialize the mbr struct to a new file.
+  * @brief initialize the FileTableEntry struct to a new file.
   *
-  * Initialize the mbr struct with the given, null-terminated filename.
-  * Ths is used to add a new file to the MBR.
+  * Initialize the FileTableEntry struct with the null-terminated filename.
+  * Ths is used to add a new file to the FT.
   * This function also sets the file size to zero,
-  * and marks the MBR as busy.
+  * and marks the FT as busy.
   *
-  * @param m the mbr struct to use fill.
+  * @param m the FileTableEntry struct to use fill.
   * @param filename the null terminated filename to use.
   * @return non-zero on success, zero on error.
   */
-int MicroBitFile::mbr_add(mbr* m, char const * const filename) {
-   
-    uint32_t t = MBR_BUSY;
+int MicroBitFile::ft_add(FileTableEntry* m, char const * filename) 
+{
+    uint32_t t = FT_BUSY;
     
     // Write the Filename.
     if(!this->flash.flash_write((uint8_t*)m->name,
@@ -71,29 +64,29 @@ int MicroBitFile::mbr_add(mbr* m, char const * const filename) {
         return 0;
     }
          
-    PRINTF("Set mbr entry, filename: %s\n", filename);
     return 1;
 }
 
 /**
-  * @brief add a new block to an MBR entry
+  * @brief add a new block to an FT entry
   *
-  * Add the numbered block to the list of blocks in an  MBR entry.
+  * Add the numbered block to the list of blocks in an  FT entry.
   * This function is used to expand the storage capacity for a file.
   *
-  * @param m the mbr entry/struct to add too.
+  * @param m the FileTableEntry entry/struct to add too.
   * @param blockNo the numbered block to append to the block list of a
-                    files' MBR.
+  *        files' FT.
   * @return non-zero on success, zero on error.
   */
-int MicroBitFile::mbr_add_block(mbr* m, uint8_t blockNo) {
+int MicroBitFile::ft_add_block(FileTableEntry* m, uint8_t blockNo) 
+{
    
     // Find the lowest unused block entry.
     int b = 0;
     for(b=0;b<DATA_BLOCK_COUNT;b++) {
  
-        // The mbr_t.blocks list is terminated by 0xFF, this is the first 
-        // unallocated block.
+        // The FileTableEntry_t.blocks list is terminated by 0xFF, 
+        // this is the first unallocated block.
         if(m->blocks[b] == 0xFF) break;
 
     }
@@ -102,21 +95,21 @@ int MicroBitFile::mbr_add_block(mbr* m, uint8_t blockNo) {
     return this->flash.flash_write(&(m->blocks[b]), &blockNo, 1);
 }
 
-
 /**
-  * @brief reset an MBR entry - remove a file from the MBR table.
+  * @brief reset an FT entry - remove a file from the FT table.
   *
-  * Reset an MBR entry, thereby removing a file from the system.
+  * Reset an FT entry, thereby removing a file from the system.
   * This function also frees all of the blocks allocated to m,
   * back to the list of free blocks.
   *
-  * @param m the mbr entry/struct to remove.
+  * @param m the FileTableEntry entry/struct to remove.
   * @return non-zero on success, zero on error.
   */
-int MicroBitFile::mbr_remove(mbr* m) {
+int MicroBitFile::ft_remove(FileTableEntry* m) 
+{
 
     // ----------------------------------------------
-    // Return block numbers in the mbr entry to the mbr_free_loc->blocks list.
+    // Return block numbers in the FileTableEntry entry to the FileTableEntry_free_loc->blocks list.
     // Add to the beginning of the list.
     //
     // So if we have before:
@@ -126,7 +119,7 @@ int MicroBitFile::mbr_remove(mbr* m) {
     // [ ][ ][1][4][5][6]
     // ----------------------------------------------
   
-    // used = no. used blocks in mbr. 
+    // used = no. used blocks in FileTableEntry. 
     int used=0;    
     for(used=0;used<DATA_BLOCK_COUNT;used++) {
         if( m->blocks[used] == 0xFF) break;
@@ -135,7 +128,7 @@ int MicroBitFile::mbr_remove(mbr* m) {
     // Where to insert into free list.
     int b = 0;     
     for(b=0;b<DATA_BLOCK_COUNT;++b) {
-        if(this->mbr_free_loc->blocks[b] != 0x00) break;
+        if(this->ft_free_loc->blocks[b] != 0x00) break;
     }
    
     //not enough room. (this shouldn't happen)
@@ -144,25 +137,23 @@ int MicroBitFile::mbr_remove(mbr* m) {
     }
     int p = b-used;
    
-    PRINTF("mbr removed. Name: %s, blocks: %d\n", m->filename, used);
-  
     // Reset the free block list entries to 0xFF.
-    if(!this->flash.flash_erase_mem((uint8_t*)&this->mbr_free_loc->blocks[p],
+    if(!this->flash.flash_erase_mem((uint8_t*)&this->ft_free_loc->blocks[p],
         used)) {
         return 0;
     }
 
     // Write each of the block numbers.   
     for(int j=0;j<used;j++) {
-        uint8_t bl = m->blocks[j] | MBR_FREE_BLOCK_MARKER;
+        uint8_t bl = m->blocks[j] | FT_FREE_BLOCK_MARKER;
 
-        if(!this->flash.flash_write(&this->mbr_free_loc->blocks[p+j],&bl,1)) {
+        if(!this->flash.flash_write(&this->ft_free_loc->blocks[p+j],&bl,1)) {
             return 0;
         }
     }
 
-    // Erase the MBR (can then be resused.
-    if(!this->flash.flash_erase_mem((uint8_t*)m, sizeof(mbr))) {
+    // Erase the FT (can then be resused.
+    if(!this->flash.flash_erase_mem((uint8_t*)m, sizeof(FileTableEntry))) {
         return 0;
     }
 
@@ -172,16 +163,17 @@ int MicroBitFile::mbr_remove(mbr* m) {
 /**
   * @brief obtains and marks as busy, an unused block.
   *
-  * The first MBR entry is reserved, and stores the list of unused blocks.
-  * Thiis function implements a stack, to pop a free block, mark as busy
+  * The first FT entry is reserved, and stores the list of unused blocks.
+  * This function implements a stack, to pop a free block, mark as busy
   * (subsequent calls will not find the same block), and return its number.
   *
   * @return block number on success, -1 on error (out of space).
   */
-int MicroBitFile::mbr_pop_free_block() {
+int MicroBitFile::ft_pop_free_block() 
+{
   
     // ----------------------------------------------
-    // Find a free block in mbr_free_loc->blocks.
+    // Find a free block in FileTableEntry_free_loc->blocks.
     // Pop from the front of the list.
     //
     // So if we have beforehand:
@@ -194,97 +186,91 @@ int MicroBitFile::mbr_pop_free_block() {
     //find the lowest free block.
     int b = 0;
     for(b=0;b<DATA_BLOCK_COUNT;b++) {
-         if(this->mbr_free_loc->blocks[b] != 0x00 &&
-            this->mbr_free_loc->blocks[b] != 0xFF) break;
+         if(this->ft_free_loc->blocks[b] != 0x00 &&
+            this->ft_free_loc->blocks[b] != 0xFF) break;
     }
     if(b==DATA_BLOCK_COUNT) {
-        PRINTF("No free blocks available\n");
         return -1;
     }
   
     //mark as unavailable in the free block list.
     uint8_t write_empty = 0x00;
-    uint8_t blockNumber = mbr_get_block(this->mbr_free_loc, b);
-    blockNumber &= ~(MBR_FREE_BLOCK_MARKER);
+    uint8_t blockNumber = ft_get_block(this->ft_free_loc, b);
+    blockNumber &= ~(FT_FREE_BLOCK_MARKER);
 
-    if(!this->flash.flash_write(&this->mbr_free_loc->blocks[b], 
+    if(!this->flash.flash_write(&this->ft_free_loc->blocks[b], 
                                 &write_empty, 1)) return -1;
   
-    PRINTF("Free block %d from location in list %d\n", blockNumber, b);
     return blockNumber;
 }
 
 /**
-  * @brief initialize the MBR API.
+  * @brief initialize the FT API.
   *
   * This function initializes the API for subsequent calls,
   * particularly storing the flash location, and number of entries.
   * This function must be called before any other.
   *
-  * @param mbr_location Location in flash of where to store the MBR.
-  * @param mbr_entries The number of entries in the MBR
-  *                    (hence determining the max no. files).
+  * @param ft_location Location in flash of where to store the FT.
+  * @param ft_entries The number of entries in the FT
+  *                   (hence determining the max no. files).
   * @return non-zero on success, zero on error.
  */
-int MicroBitFile::mbr_init(void* mbr_location, int mbr_no) {
-
-    PRINTF("initializing mbr\n");
-
-    this->mbr_free_loc = (mbr*)mbr_location;
-    this->mbr_loc = (mbr*)mbr_location + 1;
-    this->mbr_entries = mbr_no-1;
+int MicroBitFile::ft_init(void* ft_location, int no) 
+{
+    this->ft_free_loc = (FileTableEntry*)ft_location;
+    this->ft_loc = (FileTableEntry*)ft_location + 1;
+    this->ft_entries = no-1;
 
     return 1;
 }
 
 /**
-  * @brief set the filesize of an mbr
+  * @brief set the filesize of an FileTableEntry
   *
-  * Set, in the MBR, the filesize of the entry, m.
+  * Set, in the FT, the filesize of the entry, m.
   *
-  * @param m the MBR entry/file to modify
+  * @param m the FT entry/file to modify
   * @param filesize the new filesize.
   * @return non-zero on success, zero on error.
   */
-int MicroBitFile::mbr_set_filesize(mbr* m, uint32_t fz) {
-  
-    PRINTF("set filesize: %s to %d bytes\n", m->name, fz);
+int MicroBitFile::ft_set_filesize(FileTableEntry* m, uint32_t fz) 
+{
     return this->flash.flash_write((uint8_t*)&m->flags, (uint8_t*)&fz, 4);
 }
 
 /**
-  * @brief reset the MBR.
+  * @brief reset the FT.
   *
-  * The MBR must be in an initial state for it to work.
-  * Namely, all of the mbr entries must be set to empty (0xFF).
+  * The FT must be in an initial state for it to work.
+  * Namely, all of the FileTableEntry entries must be set to empty (0xFF).
   * and the stack of unused blocks must be populated.
   *
   * This function also sets the MAGIC_WORD as the first word in
-  * the MBR block, used to determine if the MBR has already been
+  * the FT block, used to determine if the FT has already been
   * configured.
   *
   * This function should be called from the init() function.
   *
   * @return non-zero on success, zero otherwise.
   */
-int MicroBitFile::mbr_build() {
+int MicroBitFile::ft_build() 
+{
   
-    // Only build the MBR table if not already initialized.
-    if(*((uint32_t*)this->mbr_free_loc) == MAGIC_WORD) {
-        PRINTF("Magic word detected, file system already built\n");
+    // Only build the FT table if not already initialized.
+    if(*((uint32_t*)this->ft_free_loc) == MAGIC_WORD) {
         return 1;
     }
-    PRINTF("Magic word not detected, building file system\n");
   
     uint32_t magic = MAGIC_WORD;
   
-    // Erase MBR Page.
-    if(!this->flash.flash_erase_mem((uint8_t*)this->mbr_free_loc, PAGE_SIZE)) {
+    // Erase FT Page.
+    if(!this->flash.flash_erase_mem((uint8_t*)this->ft_free_loc, PAGE_SIZE)) {
         return 0;
     }
   
     // Write Magic.
-    if(!this->flash.flash_write((uint8_t*)this->mbr_free_loc->name,
+    if(!this->flash.flash_write((uint8_t*)this->ft_free_loc->name,
                                 (uint8_t*)&magic, sizeof(magic))) {
         return 0;
     }
@@ -292,43 +278,43 @@ int MicroBitFile::mbr_build() {
     // Populate the free block list.
     uint8_t bl[DATA_BLOCK_COUNT-1];
     for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) {
-        bl[i] = i | MBR_FREE_BLOCK_MARKER;
+        bl[i] = i | FT_FREE_BLOCK_MARKER;
     }
   
-    return this->flash.flash_write((uint8_t*)&this->mbr_free_loc->blocks, 
+    return this->flash.flash_write((uint8_t*)&this->ft_free_loc->blocks, 
                                     bl, DATA_BLOCK_COUNT-1);
 }
+
 
 /**
   * Constructor. Calls the necessary init() functions.
   */
-MicroBitFile::MicroBitFile() {
-    int initialized = this->init();
-    PRINTF("initializing.. %d\n", initialized);
-    memset(this->fd_table, 0x00, sizeof(tinyfs_fd) * MAX_FD);
+MicroBitFile::MicroBitFile() 
+{
+    this->init();
+    memset(this->fd_table, 0x00, sizeof(mb_fd) * MAX_FD);
 }
 
 /**
   * @brief Initialize the flash storage system
   *
   * This method:
-  * - calls mbr_init().
+  * - calls ft_init().
   * - stores the location of the flash memory.
-  * - calls mbr_build()
+  * - calls ft_build()
   *
   * @return non-zero on success, zero on error.
   */
-int MicroBitFile::init() {
+int MicroBitFile::init() 
+{
     if(FS_INITIALIZED()) return 0;
 
-    // MBR-specific init/build.   
-    if(!this->mbr_init((uint8_t*)FLASH_START, NO_MBR_ENTRIES)) return 0;
-    if(!this->mbr_build()) return 0;
+    // FT-specific init/build.   
+    if(!this->ft_init((uint8_t*)FLASH_START, NO_FT_ENTRIES)) return 0;
+    if(!this->ft_build()) return 0;
    
-    PRINTF("initialized\n");
-     
     this->flash_start = (uint8_t*)FLASH_START + PAGE_SIZE;
-    this->flash_pages = NO_MBR_ENTRIES-1;
+    this->flash_pages = NO_FT_ENTRIES-1;
 
     return 1;
 }
@@ -358,41 +344,40 @@ int MicroBitFile::init() {
   *    print("file open error");
   * @endcode
   */
-int MicroBitFile::open(char const * const filename, uint8_t flags) {
+int MicroBitFile::open(char const * filename, uint8_t flags) 
+{
     if(!FS_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return -1;
    
-    mbr* m;
+    FileTableEntry* m;
     int fd;
    
     //find the file, if it already exists.
-    if((m = this->mbr_by_name(filename)) == NULL) {
+    if((m = this->ft_by_name(filename)) == NULL) {
 
         // File doesn't exist, try to create it.
-        if((flags & MB_CREAT) != MB_CREAT || 
-           (m = this->mbr_get_free()) == NULL || 
-           !this->mbr_add(m, filename)) {
+        if(!(flags & MB_CREAT) || 
+           (m = this->ft_get_free()) == NULL || 
+           !this->ft_add(m, filename)) {
 
-            // Couldn't set the MBR entry.
+            // Couldn't set the FT entry.
             return -1;
         }
    
-        PRINTF("open: file created %s\n", filename);
     }
    
     //find a free FD.
     for(fd=0;fd<MAX_FD;fd++) {
-        if((this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) break;
+        if(!(this->fd_table[fd].flags & MB_FD_BUSY)) break;
     }
     if(fd == MAX_FD) {
         return -1;
-        PRINTF("No free FDs\n");
     }
    
     //populate the fd.
     this->fd_table[fd].flags = (flags & ~(MB_CREAT)) | MB_FD_BUSY;
-    this->fd_table[fd].mbr_entry = m;
+    this->fd_table[fd].ft_entry = m;
     this->fd_table[fd].seek = 0;
-    this->fd_table[fd].filesize = mbr_get_filesize(m);
+    this->fd_table[fd].filesize = ft_get_filesize(m);
     return fd;
 }
 
@@ -400,10 +385,10 @@ int MicroBitFile::open(char const * const filename, uint8_t flags) {
   * Close the specified file handle.
   * File handle resources are then made available for future open() calls.
   *
-  * tfs_close() must be called at some point to ensure the filesize in the
-  * MBR is synced with the cached value in the FD.
+  * close() must be called at some point to ensure the filesize in the
+  * FT is synced with the cached value in the FD.
   *
-  * @warning if tfs_close() is not called, the MBR may not be correct, l
+  * @warning if close() is not called, the FT may not be correct,
   * leading to data loss.
   *
   * @param fd file descriptor - obtained with open().
@@ -417,11 +402,12 @@ int MicroBitFile::open(char const * const filename, uint8_t flags) {
   *    print("error closing file.");
   * @endcode
   */
-int MicroBitFile::close(int fd) {
+int MicroBitFile::close(int fd) 
+{
     if(!FS_INITIALIZED() ||
-      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return 0;
+      !(this->fd_table[fd].flags & MB_FD_BUSY)) return 0;
 
-    this->mbr_set_filesize(this->fd_table[fd].mbr_entry,
+    this->ft_set_filesize(this->fd_table[fd].ft_entry,
                            this->fd_table[fd].filesize);
 
     this->fd_table[fd].flags = 0x00;
@@ -450,9 +436,10 @@ int MicroBitFile::close(int fd) {
   * f.seek(fd, -100, MB_SEEK_END); //100 bytes before end of file.
   * @endcode
   */
-int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
+int MicroBitFile::seek(int fd, int offset, uint8_t flags) 
+{
     if(!FS_INITIALIZED() ||
-      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return -1;
+      !(this->fd_table[fd].flags & MB_FD_BUSY)) return -1;
     
     int32_t new_pos = 0;
     int max_size = this->fd_table[fd].filesize;
@@ -468,8 +455,6 @@ int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
         new_pos = this->fd_table[fd].seek + offset;
     }
     else {
-        PRINTF("seek range error, offset %d, flag %d, fd %dn", 
-               offset, flags, fd);
         return -1;
     }  
    
@@ -480,9 +465,9 @@ int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
 /**
   * Read data from the file.
   *
-  * Read len bytes from the current seek position in the file, into the buffer.
-  * On each invocation to read, the seek position of the file handle
-  * is incremented atomically, by the number of bytes returned.
+  * Read len bytes from the current seek position in the file, into the
+  * buffer. On each invocation to read, the seek position of the file
+  * handle is incremented atomically, by the number of bytes returned.
   *
   * @param fd File handle, obtained with open()
   * @param buffer to store data
@@ -497,10 +482,11 @@ int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
   *    print("read error");
   * @endcode
   */
-int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
+int MicroBitFile::read(int fd, uint8_t* buffer, int size) 
+{
     if(!FS_INITIALIZED() ||
-      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
-      (this->fd_table[fd].flags & MB_READ) != MB_READ) return -1;
+      !(this->fd_table[fd].flags & MB_FD_BUSY) ||
+      !(this->fd_table[fd].flags & MB_READ)) return -1;
    
     // Basic algorithm:
     // Find the starting block number & offset,
@@ -533,7 +519,7 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
     for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) {
 
         // b = block number.
-        int b = mbr_get_block(this->fd_table[fd].mbr_entry, bInd);
+        int b = ft_get_block(this->fd_table[fd].ft_entry, bInd);
 
         // s  no. bytes to read from this page.
         int s = MIN(PAGE_SIZE-ofs,sz);
@@ -542,8 +528,6 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
         if((this->fd_table[fd].seek+s) > filesize) {
             s = filesize - this->fd_table[fd].seek;
         }
-
-        PRINTF("Read %d bytes from block %d (%d) offset: %d\n",s,bInd,b,ofs);
 
         memcpy( buffer, flash_start + (PAGE_SIZE * b) + ofs, s);
 
@@ -558,7 +542,6 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
     return bytesRead;
 }
 
-
 /**
   * Write data to the file.
   *
@@ -567,8 +550,8 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
   * is incremented atomically, by the number of bytes returned.
   *
   * The cached filesize in the FD is updated on this call. Also, the
-  * MBR file size is updated only if a new page(s) has been written too,
-  * to reduce the number of MBR writes.
+  * FT file size is updated only if a new page(s) has been written too,
+  * to reduce the number of FT writes.
   *
   * @param fd File handle
   * @param buffer the buffer from which to write data
@@ -580,13 +563,14 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
   * MicroBitFile f();
   * int fd = f.open("test.txt", MB_WRITE);
   * if(f.write(fd, "hello!", 7) != 7)
-       print("error writing");
+  *    print("error writing");
   * @endcode
   */
-int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
+int MicroBitFile::write(int fd, uint8_t* buffer, int size) 
+{
     if(!FS_INITIALIZED() ||
-      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
-      (this->fd_table[fd].flags & MB_WRITE) != MB_WRITE) return -1;
+      !(this->fd_table[fd].flags & MB_FD_BUSY) ||
+      !(this->fd_table[fd].flags & MB_WRITE)) return -1;
    
     // Basic algorithm for writing:
     //
@@ -601,7 +585,7 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
     //   b = pop_free_block()
     //   newPages=1
     //  else
-    //   b = get absolute block No. from MBR
+    //   b = get absolute block No. from FT
     //  end
     //
     //  flash_write(flash_start + b + ofs, buffer, wr)
@@ -611,7 +595,7 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
     // end
     //
     // if [newPages]
-    //  write file size to MBR
+    //  write file size to FT
     // end
     //
     // return bytesWritten
@@ -633,24 +617,20 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
         if(bInd >= allocated_blocks) { 
 
            // File must increase in size, append with new block.
-            if( (b = mbr_pop_free_block()) < 0) {
+            if( (b = ft_pop_free_block()) < 0) {
                 break;
             }
-            if(!mbr_add_block(this->fd_table[fd].mbr_entry, b)) {
+            if(!ft_add_block(this->fd_table[fd].ft_entry, b)) {
                 break;
             }
 
             allocated_blocks++;
             newPages=1;
-            PRINTF("New block allocated: %d\n", b);
         }
         else {
            // Write position requires no new block allocation.
-            b = mbr_get_block(this->fd_table[fd].mbr_entry, bInd);
+            b = ft_get_block(this->fd_table[fd].ft_entry, bInd);
         }
-
-        PRINTF("Write %s block index %d, number %d, offset %d, length %d\n",
-               (writeData?"data":"0x00"), bInd, b, ofs, wr);
 
         if(!this->flash.flash_write(this->flash_start+(PAGE_SIZE*b)+ofs,
                                     buffer,wr)) {
@@ -670,7 +650,7 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
 
     //change the file size if we used new pages.
     if(newPages) {
-        if(!this->mbr_set_filesize(this->fd_table[fd].mbr_entry, 
+        if(!this->ft_set_filesize(this->fd_table[fd].ft_entry, 
                                    this->fd_table[fd].filesize)) {
             return -1;
         }
@@ -690,19 +670,19 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
   * Example:
   * @code
   * MicroBitFile f;
-  * if(!f.unlink("file.txt"))
-  *     print("file could not be deleted")
+  * if(!f.remove("file.txt"))
+  *     print("file could not be removed")
   * @endcode
   */
-int MicroBitFile::unlink(char const * const filename) {
+int MicroBitFile::remove(char const * filename) 
+{
     if(!FS_INITIALIZED()) return 0;
    
-    // Get the mbr to remove.
-    mbr* m = this->mbr_by_name(filename);
+    // Get the FileTableEntry to remove.
+    FileTableEntry* m = this->ft_by_name(filename);
     if(m == NULL) {
-        PRINTF("cannot unlink %s, not found\n", filename);
         return 0;
     }
     
-    return this->mbr_remove(m);
+    return this->ft_remove(m);
 }

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -1,0 +1,479 @@
+#include <stddef.h>
+#include <string.h>
+#include "MicroBitFile_config.h"
+#include "MicroBitFile.h"
+#include "MicroBitFlash.h"
+
+// Test if init()/mbr_init have been called.
+#define FS_INITIALIZED() (this->flash_start != NULL)
+#define MBR_INITIALIZED() (this->mbr_loc != NULL)
+
+// Check if a mbr pointer is within table.
+#define MBR_PTR_VALID(p) ( (p >= this->mbr_loc) && (p-this->mbr_loc)<=(this->mbr_entries-1) )
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+#define DEBUG 0
+#if DEBUG
+#define PRINTF(...) uBit.serial.printf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+/*
+ * Search for an MBR entry by name
+ */
+mbr* MicroBitFile::mbr_by_name(char const * const filename) {
+ if(!MBR_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return NULL;
+
+ for(int i=0;i<this->mbr_entries;++i) {
+  if(strcmp(filename, this->mbr_loc[i].name) == 0) return &this->mbr_loc[i];
+ }
+ return NULL;
+}
+/*
+ * Find the lowest numbered available MBR entry 
+ */
+mbr* MicroBitFile::mbr_get_free() {
+ if(!MBR_INITIALIZED()) return NULL;
+
+ for(int i=0;i<this->mbr_entries;++i) {
+  if(MBR_IS_FREE(this->mbr_loc[i])) return &this->mbr_loc[i];
+ }
+ return NULL;
+}
+
+/*
+ * Initialize an MBR entry with Filename, mark as unavailable, and 
+ * set filesize = 0.
+ */
+int MicroBitFile::mbr_add(mbr* m, char const * const filename) {
+ if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) ||
+    !MBR_IS_FREE((*m)) || strlen(filename) > MAX_FILENAME_LEN) return 0;
+
+ uint32_t t = MBR_BUSY;
+ if(!this->flash.flash_write((uint8_t*)m->name, (uint8_t*)filename, strlen(filename)+1) ||
+    !this->flash.flash_write((uint8_t*)&(m->flags), (uint8_t*)&t, sizeof(t))) return 0;
+
+ PRINTF("Set mbr entry, filename: %s\n", filename);
+ return 1;
+}
+
+/*
+ * Add a data block to an MBR entry
+ */
+int MicroBitFile::mbr_add_block(mbr* m, uint8_t blockNo) {
+ if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
+
+ //find the lowest unused block entry.
+ int b = 0;
+ for(b=0;b<DATA_BLOCK_COUNT;b++) {
+  if(m->blocks[b] == 0xFF) break;
+ }
+ if(b==DATA_BLOCK_COUNT) return 0;
+
+ //okay.
+ return this->flash.flash_write(&(m->blocks[b]), &blockNo, 1);
+}
+
+// ----------------------------------------------
+// Return block numbers in the mbr_t entry to the mbr_free_loc->blocks list.
+// Add to the beginning of the list.
+//
+// So if we have before:
+// [ ][ ][ ][4][5][6]
+//
+// Inserting '1' Will then become:
+// [ ][ ][1][4][5][6]
+// ----------------------------------------------
+int MicroBitFile::mbr_remove(mbr* m) {
+ if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
+
+ int used=0;    // used = no. used blocks in mbr.
+ for(used=0;used<DATA_BLOCK_COUNT;used++) {
+  if( m->blocks[used] == 0xFF) break;
+ }
+
+ int b = 0;     // Where to insert into free list.
+ for(b=0;b<DATA_BLOCK_COUNT;++b) {
+  if(this->mbr_free_loc->blocks[b] != 0x00) break;
+ }
+
+ if(used > b) { //not enough room...
+  return 0;
+ }
+ int p = b-used;
+
+ PRINTF("mbr removed. Name: %s, blocks: %d\n", m->filename, used);
+
+ if(!this->flash.flash_erase_mem((uint8_t*)&this->mbr_free_loc->blocks[p],used)) return 0;
+
+ for(int j=0;j<used;j++) {
+  uint8_t bl = m->blocks[j] | MBR_FREE_BLOCK_MARKER;
+  if(!this->flash.flash_write(&this->mbr_free_loc->blocks[p+j], &bl, 1)) return 0;
+ }
+ return this->flash.flash_erase_mem((uint8_t*)m, sizeof(mbr));
+}
+
+// ----------------------------------------------
+// Find a free block in mbr_free_loc->blocks.
+// Pop from the front of the list.
+//
+// So if we have beforehand:
+// [1][2][3][4][5][6]
+//
+// Will become:
+// [ ][2][3][4][5][6]
+// ----------------------------------------------
+int MicroBitFile::mbr_pop_free_block() {
+  if(!MBR_INITIALIZED()) return -1;
+
+  //find the lowest free block.
+  int b = 0;
+  for(b=0;b<DATA_BLOCK_COUNT;b++) {
+   if(this->mbr_free_loc->blocks[b] != 0x00 &&
+      this->mbr_free_loc->blocks[b] != 0xFF) break;
+  }
+  if(b==DATA_BLOCK_COUNT) {
+    PRINTF("No free blocks available\n");
+    return -1;
+  }
+
+  //mark as unavailable.
+  uint8_t write_empty = 0x00;
+  uint8_t blockNumber = this->mbr_free_loc->blocks[b] &= ~(MBR_FREE_BLOCK_MARKER);
+  if(!this->flash.flash_write(&this->mbr_free_loc->blocks[b], &write_empty, 1)) return -1;
+
+  PRINTF("Free block %d from location in list %d\n", blockNumber, b);
+  return blockNumber;
+}
+
+/*
+ * Initialize the MBR functions, with pointers to the MBR page in flash.
+ */
+int MicroBitFile::mbr_init(void* mbr_location, int mbr_no) {
+  if(MBR_INITIALIZED()) return 0;
+  uBit.serial.printf("initializing mbr\n");
+  this->mbr_free_loc = (mbr*)mbr_location;
+  this->mbr_loc = (mbr*)mbr_location + 1;
+  this->mbr_entries = mbr_no-1;
+  return 1;
+}
+
+/*
+ * Set the filesize attribute of an MBR entry 
+ */
+int MicroBitFile::mbr_set_filesize(mbr* m, uint32_t fz) {
+  if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) || MBR_IS_FREE(*m)) return 0;
+
+  PRINTF("set filesize: %s to %d bytes\n", m->name, fz);
+  return this->flash.flash_write((uint8_t*)&m->flags, (uint8_t*)&fz, 4);
+}
+
+/*
+ * Check if the Master Boot Record (MBR) table has already been initialized.
+ * Initialize if not.
+ */
+int MicroBitFile::mbr_build() {
+  if(!MBR_INITIALIZED()) return 0;
+
+  // Only build the MBR table if not already initialized...
+  if(*((uint32_t*)this->mbr_free_loc) == MAGIC_WORD) {
+    uBit.serial.printf("Magic word detected, file system already built\n");
+    return 1;
+  }
+  uBit.serial.printf("Magic word not detected, building file system\n");
+
+  uint32_t magic = MAGIC_WORD;
+
+  // Erase MBR Page.
+  if(!this->flash.flash_erase_mem((uint8_t*)this->mbr_free_loc, PAGE_SIZE)) return 0;
+
+  // Write Magic.
+  if(!this->flash.flash_write((uint8_t*)this->mbr_free_loc->name,
+                  (uint8_t*)&magic, sizeof(magic))) return 0;
+
+
+  // Write Free data blocks.
+  uint8_t bl[DATA_BLOCK_COUNT-1];
+  for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) bl[i] = i | MBR_FREE_BLOCK_MARKER;
+
+  return this->flash.flash_write((uint8_t*)&this->mbr_free_loc->blocks, bl, DATA_BLOCK_COUNT-1);
+}
+
+/*
+ * Constructor
+ */
+MicroBitFile::MicroBitFile() {
+ uBit.serial.printf("initializing.. %d\n", this->init());
+ memset(this->fd_table, 0x00, sizeof(tinyfs_fd) * MAX_FD);
+}
+
+/*
+ * Init function, call mbr_init and mbr_build, store the flash memory location.
+ */
+int MicroBitFile::init() {
+ if(FS_INITIALIZED()) return 0;
+
+ if(!this->mbr_init((uint8_t*)FLASH_START, NO_MBR_ENTRIES)) return 0;
+
+ if(!this->mbr_build()) return 0;
+
+ uBit.serial.printf("initialized\n");
+  
+ this->flash_start = (uint8_t*)FLASH_START + PAGE_SIZE;
+ this->flash_pages = NO_MBR_ENTRIES-1;
+ return 1;
+}
+
+/*
+ * Open a file, and obtain a file handle.
+ */
+int MicroBitFile::open(char const * const filename, uint8_t flags) {
+ if(!FS_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return -1;
+
+ mbr* m;
+ int fd;
+
+ //find, or create, the file.
+ if((m = this->mbr_by_name(filename)) == NULL) {
+  if((flags & MB_CREAT) != MB_CREAT || 
+     (m = this->mbr_get_free()) == NULL || 
+     !this->mbr_add(m, filename)) return -1;
+
+  PRINTF("open: file created %s\n", filename);
+ }
+
+ //find a free FD.
+ for(fd=0;fd<MAX_FD;fd++) {
+  if((this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) break;
+ }
+ if(fd == MAX_FD) {
+   return -1;
+   PRINTF("No free FDs\n");
+ }
+
+ //populate the fd.
+ this->fd_table[fd].flags = (flags & ~(MB_CREAT)) | MB_FD_BUSY;
+ this->fd_table[fd].mbr_entry = m;
+ this->fd_table[fd].seek = 0;
+ return fd;
+}
+
+/*
+ * Close file handle, FD available for re-use.
+ */
+int MicroBitFile::close(int fd) {
+ if(!FS_INITIALIZED() ||
+   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return 0;
+
+ this->fd_table[fd].flags = 0x00;
+ return 1;
+}
+
+/*
+ * Seek to a set position in the file
+ */
+int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
+ if(!FS_INITIALIZED() ||
+   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return -1;
+ 
+ int32_t new_pos = 0;
+ int max_size = mbr_get_filesize(this->fd_table[fd].mbr_entry);
+
+ if(flags == MB_SEEK_SET && offset <= max_size) {
+   new_pos = offset;
+ }
+ else if(flags == MB_SEEK_END && offset <= max_size) {
+   new_pos = max_size+offset;
+ }
+ else if(flags == MB_SEEK_CUR && (this->fd_table[fd].seek+offset) <= max_size) {
+   new_pos = this->fd_table[fd].seek + offset;
+ }
+ else {
+  PRINTF("seek range error, offset %d, flag %d, fd %dn", offset, flags, fd);
+  return -1;
+ }
+
+ this->fd_table[fd].seek = new_pos;
+ return new_pos;
+}
+
+// Basic algorithm:
+// Find the starting block number & offset,
+//
+//  blockInd = starting block index in list
+//  blockOffset = offset within first block
+// 
+//  while [still have bytes to read
+//   b = block number (from blockInd)
+//   s = how many bytes to read from this block
+//   if(s > bytes remaining in file)
+//    s = bytes remaining in file
+//   end
+// 
+//   memcpy(destination buffer, this->flash_start + (b * PAGE_SIZE) + blockOffset)
+//   seek += s
+//   bytesRead += s 
+//   blockOffset = 0
+//   blockInd++
+//  end
+//
+//  return bytesRead
+//
+int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
+ if(!FS_INITIALIZED() ||
+   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
+   (this->fd_table[fd].flags & MB_READ) != MB_READ) return -1;
+
+ int blockInd = this->fd_table[fd].seek / PAGE_SIZE;
+ int blockOffset = this->fd_table[fd].seek % PAGE_SIZE;
+ int32_t filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry);
+ int bytesRead = 0;
+
+ for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) {
+
+  int b = mbr_get_block(this->fd_table[fd].mbr_entry, blockInd);
+  int s = MIN(PAGE_SIZE-blockOffset,sz);
+  if((this->fd_table[fd].seek+s) > filesize) {
+   s = filesize - this->fd_table[fd].seek;
+  }
+
+  PRINTF("Read %d bytes from block %d (%d) offset: %d\n",
+	s, blockInd, b, s, blockOffset);
+
+  memcpy( buffer, this->flash_start + (PAGE_SIZE * b) + blockOffset, s);
+ 
+  sz -= s;
+  buffer += s;
+  blockInd++;
+  blockOffset=0;
+  this->fd_table[fd].seek += s;
+  bytesRead += s;
+ }
+
+ return bytesRead;
+}
+
+// More complex than tfs_read(), because we have to account for the
+// file increasing in size, and padding 0x00 if starting past current end.
+// 
+// allocated_blocks = current no. allocated blocks to mbr
+// 
+// while still data to write
+//  if(seek extends beyond current file size)
+//   bInd = final block in file
+//   ofs = current end-offset in last block
+//   wr = how many bytes to write 0x00 to
+//   writeData = false (don't write data on this iteration, just fill 0x00)
+//  else
+//   bInd = block Index to start writing.
+//   ofs = offset within block
+//   wr = number of bytes to write.
+//   writeData = true (write data from buffer on this iteration)
+//  end
+// 
+//  if(bInd >= allocated_blocks)
+//   b = pop_free_block()
+//   add_block(b)
+//  else
+//   b = get_block(bInd)
+//  end
+// 
+//  if(writeData)
+//   write to(this->flash_start + PAGE_SIZE * b + ofs, buffer, wr)
+//  else
+//   flash_memset(this->flash_start + PAGE_SIZE + b + ofs, 0x00, wr)
+//  end
+// 
+//  bytesWritten += wr
+//  bInd++
+// 
+//  return bytesWritten
+//  
+int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
+ if(!FS_INITIALIZED() ||
+   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
+   (this->fd_table[fd].flags & MB_WRITE) != MB_WRITE) return -1;
+
+ int bInd; //block index
+ int b; //absolute block number to write.
+ int ofs; //offset within block to write.
+ int wr; //no. bytes to write on a pass.
+ 
+ int bytesWritten = 0;
+ int writeData; //flag: 1=write data, 0=pad 0x00.
+
+ int filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry); 
+ int origSize = filesize;
+
+ int allocated_blocks = filesize / PAGE_SIZE; //current no. blocks assigned.
+ if( (filesize % PAGE_SIZE) != 0) allocated_blocks++;
+
+ for(int sz = size;sz > 0;) {
+
+  if(this->fd_table[fd].seek > filesize) {
+   bInd = (filesize) / PAGE_SIZE;
+   ofs = (filesize) % PAGE_SIZE;
+   wr = MIN(PAGE_SIZE-ofs, this->fd_table[fd].seek-filesize);
+   writeData = 0;
+  }
+  else { //starting beyond current file end, pad 0x00.
+   bInd = this->fd_table[fd].seek / PAGE_SIZE;
+   ofs = this->fd_table[fd].seek % PAGE_SIZE;
+   wr = MIN(PAGE_SIZE-ofs,sz);
+   writeData = 1;
+  }
+ 
+  if(bInd >= allocated_blocks) { // Get the block number, or allocate one.
+   if( (b = this->mbr_pop_free_block()) < 0 || 
+      ! this->mbr_add_block(this->fd_table[fd].mbr_entry, b) ) break;
+
+   allocated_blocks++;
+   PRINTF("New block allocated: %d\n", b);
+  }
+  else {
+   b = mbr_get_block(this->fd_table[fd].mbr_entry, bInd);
+  } 
+
+  PRINTF("Write %s block index %d, number %d, offset %d, length %d\n",
+         (writeData?"data":"0x00"), bInd, b, ofs, wr);
+
+  if(writeData) { //write data from buffer.
+   if(!this->flash.flash_write( this->flash_start + (PAGE_SIZE * b) + ofs, buffer, wr)) break;
+   if((this->fd_table[fd].seek + wr) > filesize) { //set the new file length
+    filesize = this->fd_table[fd].seek + wr;
+   }
+
+   sz -= wr; 
+   buffer += wr;
+   this->fd_table[fd].seek += wr;
+  }
+  else { //write 0x00 to pad.
+   if(!this->flash.flash_memset( this->flash_start + (PAGE_SIZE * b) + ofs, 0x00, wr)) break;
+   filesize += wr; //set the new file length.
+  }
+
+  bytesWritten += wr;
+ }
+
+ if(origSize != filesize) {
+   if(!this->mbr_set_filesize(this->fd_table[fd].mbr_entry, filesize))return -1;
+ }
+ return bytesWritten;
+}
+
+/*
+ * Delete a file. This deletes atomically.
+ */ 
+int MicroBitFile::unlink(char const * const filename) {
+ if(!FS_INITIALIZED()) return 0;
+
+ mbr* m = this->mbr_by_name(filename);
+ if(m == NULL) {
+  PRINTF("cannot unlink %s, not found\n", filename);
+  return 0;
+ }
+ 
+ return this->mbr_remove(m);
+}

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -14,8 +14,10 @@
   */
 FileTableEntry* MicroBitFile::ft_by_name(char const * filename) 
 {
-    for(int i=0;i<this->ft_entries;++i) {
-        if(strcmp(filename, this->ft_loc[i].name) == 0) {
+    for(int i=0;i<this->ft_entries;++i) 
+    {
+        if(strcmp(filename, this->ft_loc[i].name) == 0) 
+        {
             return &this->ft_loc[i];
         }
     }
@@ -30,7 +32,8 @@ FileTableEntry* MicroBitFile::ft_by_name(char const * filename)
   */
 FileTableEntry* MicroBitFile::ft_get_free() 
 {
-    for(int i=0;i<this->ft_entries;++i) {
+    for(int i=0;i<this->ft_entries;++i) 
+    {
         if(FT_IS_FREE(this->ft_loc[i])) return &this->ft_loc[i];
     }
     return NULL;
@@ -54,13 +57,15 @@ int MicroBitFile::ft_add(FileTableEntry* m, char const * filename)
     
     // Write the Filename.
     if(!this->flash.flash_write((uint8_t*)m->name,
-                                (uint8_t*)filename, strlen(filename)+1)) {
+                                (uint8_t*)filename, strlen(filename)+1)) 
+    {
         return 0;
     }
 
     // Write the flags/file size.
     if(!this->flash.flash_write((uint8_t*)&(m->flags),
-                                (uint8_t*)&t, sizeof(t))) {
+                                (uint8_t*)&t, sizeof(t))) 
+    {
         return 0;
     }
          
@@ -83,7 +88,8 @@ int MicroBitFile::ft_add_block(FileTableEntry* m, uint8_t blockNo)
    
     // Find the lowest unused block entry.
     int b = 0;
-    for(b=0;b<DATA_BLOCK_COUNT;b++) {
+    for(b=0;b<DATA_BLOCK_COUNT;b++) 
+    {
  
         // The FileTableEntry_t.blocks list is terminated by 0xFF, 
         // this is the first unallocated block.
@@ -121,39 +127,46 @@ int MicroBitFile::ft_remove(FileTableEntry* m)
   
     // used = no. used blocks in FileTableEntry. 
     int used=0;    
-    for(used=0;used<DATA_BLOCK_COUNT;used++) {
+    for(used=0;used<DATA_BLOCK_COUNT;used++) 
+    {
         if( m->blocks[used] == 0xFF) break;
     }
    
     // Where to insert into free list.
     int b = 0;     
-    for(b=0;b<DATA_BLOCK_COUNT;++b) {
+    for(b=0;b<DATA_BLOCK_COUNT;++b) 
+    {
         if(this->ft_free_loc->blocks[b] != 0x00) break;
     }
    
     //not enough room. (this shouldn't happen)
-    if(used > b) { 
+    if(used > b) 
+    { 
         return 0;
     }
     int p = b-used;
    
     // Reset the free block list entries to 0xFF.
     if(!this->flash.flash_erase_mem((uint8_t*)&this->ft_free_loc->blocks[p],
-        used)) {
+        used)) 
+    {
         return 0;
     }
 
     // Write each of the block numbers.   
-    for(int j=0;j<used;j++) {
+    for(int j=0;j<used;j++) 
+    {
         uint8_t bl = m->blocks[j] | FT_FREE_BLOCK_MARKER;
 
-        if(!this->flash.flash_write(&this->ft_free_loc->blocks[p+j],&bl,1)) {
+        if(!this->flash.flash_write(&this->ft_free_loc->blocks[p+j],&bl,1)) 
+        {
             return 0;
         }
     }
 
     // Erase the FT (can then be resused.
-    if(!this->flash.flash_erase_mem((uint8_t*)m, sizeof(FileTableEntry))) {
+    if(!this->flash.flash_erase_mem((uint8_t*)m, sizeof(FileTableEntry))) 
+    {
         return 0;
     }
 
@@ -185,11 +198,13 @@ int MicroBitFile::ft_pop_free_block()
   
     //find the lowest free block.
     int b = 0;
-    for(b=0;b<DATA_BLOCK_COUNT;b++) {
+    for(b=0;b<DATA_BLOCK_COUNT;b++) 
+    {
          if(this->ft_free_loc->blocks[b] != 0x00 &&
             this->ft_free_loc->blocks[b] != 0xFF) break;
     }
-    if(b==DATA_BLOCK_COUNT) {
+    if(b==DATA_BLOCK_COUNT) 
+    {
         return -1;
     }
   
@@ -258,26 +273,30 @@ int MicroBitFile::ft_build()
 {
   
     // Only build the FT table if not already initialized.
-    if(*((uint32_t*)this->ft_free_loc) == MAGIC_WORD) {
+    if(*((uint32_t*)this->ft_free_loc) == MAGIC_WORD) 
+    {
         return 1;
     }
   
     uint32_t magic = MAGIC_WORD;
   
     // Erase FT Page.
-    if(!this->flash.flash_erase_mem((uint8_t*)this->ft_free_loc, PAGE_SIZE)) {
+    if(!this->flash.flash_erase_mem((uint8_t*)this->ft_free_loc, PAGE_SIZE)) 
+    {
         return 0;
     }
   
     // Write Magic.
     if(!this->flash.flash_write((uint8_t*)this->ft_free_loc->name,
-                                (uint8_t*)&magic, sizeof(magic))) {
+                                (uint8_t*)&magic, sizeof(magic))) 
+    {
         return 0;
     }
   
     // Populate the free block list.
     uint8_t bl[DATA_BLOCK_COUNT-1];
-    for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) {
+    for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) 
+    {
         bl[i] = i | FT_FREE_BLOCK_MARKER;
     }
   
@@ -352,13 +371,13 @@ int MicroBitFile::open(char const * filename, uint8_t flags)
     int fd;
    
     //find the file, if it already exists.
-    if((m = this->ft_by_name(filename)) == NULL) {
-
+    if((m = this->ft_by_name(filename)) == NULL) 
+    {
         // File doesn't exist, try to create it.
         if(!(flags & MB_CREAT) || 
            (m = this->ft_get_free()) == NULL || 
-           !this->ft_add(m, filename)) {
-
+           !this->ft_add(m, filename)) 
+        {
             // Couldn't set the FT entry.
             return -1;
         }
@@ -366,10 +385,12 @@ int MicroBitFile::open(char const * filename, uint8_t flags)
     }
    
     //find a free FD.
-    for(fd=0;fd<MAX_FD;fd++) {
+    for(fd=0;fd<MAX_FD;fd++) 
+    {
         if(!(this->fd_table[fd].flags & MB_FD_BUSY)) break;
     }
-    if(fd == MAX_FD) {
+    if(fd == MAX_FD) 
+    {
         return -1;
     }
    
@@ -444,17 +465,21 @@ int MicroBitFile::seek(int fd, int offset, uint8_t flags)
     int32_t new_pos = 0;
     int max_size = this->fd_table[fd].filesize;
    
-    if(flags == MB_SEEK_SET && offset <= max_size) {
+    if(flags == MB_SEEK_SET && offset <= max_size) 
+    {
         new_pos = offset;
     }
-    else if(flags == MB_SEEK_END && offset <= max_size) {
+    else if(flags == MB_SEEK_END && offset <= max_size) 
+    {
         new_pos = max_size+offset;
     }
     else if(flags == MB_SEEK_CUR && 
-           (this->fd_table[fd].seek+offset) <= max_size) {
+           (this->fd_table[fd].seek+offset) <= max_size) 
+    {
         new_pos = this->fd_table[fd].seek + offset;
     }
-    else {
+    else 
+    {
         return -1;
     }  
    
@@ -516,8 +541,8 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size)
     int32_t filesize = this->fd_table[fd].filesize; 
     int bytesRead = 0;
 
-    for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) {
-
+    for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) 
+    {
         // b = block number.
         int b = ft_get_block(this->fd_table[fd].ft_entry, bInd);
 
@@ -525,7 +550,8 @@ int MicroBitFile::read(int fd, uint8_t* buffer, int size)
         int s = MIN(PAGE_SIZE-ofs,sz);
 
         //Can't read beyond the end of the file.
-        if((this->fd_table[fd].seek+s) > filesize) {
+        if((this->fd_table[fd].seek+s) > filesize) 
+        {
             s = filesize - this->fd_table[fd].seek;
         }
 
@@ -607,38 +633,45 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size)
     int allocated_blocks = filesize / PAGE_SIZE; //current no. blocks assigned.
     if( (filesize % PAGE_SIZE) != 0) allocated_blocks++;
 
-    for(int sz = size;sz > 0;) {
+    for(int sz = size;sz > 0;) 
+    {
 
         int bInd = this->fd_table[fd].seek / PAGE_SIZE; // Block index.
         int ofs = this->fd_table[fd].seek % PAGE_SIZE;  // offset within block.
         int wr = MIN(PAGE_SIZE-ofs,sz);  // No. bytes to write.
         int b = 0;                       //absolute block number.
 
-        if(bInd >= allocated_blocks) { 
+        if(bInd >= allocated_blocks) 
+        { 
 
            // File must increase in size, append with new block.
-            if( (b = ft_pop_free_block()) < 0) {
+            if( (b = ft_pop_free_block()) < 0) 
+            {
                 break;
             }
-            if(!ft_add_block(this->fd_table[fd].ft_entry, b)) {
+            if(!ft_add_block(this->fd_table[fd].ft_entry, b)) 
+            {
                 break;
             }
 
             allocated_blocks++;
             newPages=1;
         }
-        else {
+        else 
+        {
            // Write position requires no new block allocation.
             b = ft_get_block(this->fd_table[fd].ft_entry, bInd);
         }
 
         if(!this->flash.flash_write(this->flash_start+(PAGE_SIZE*b)+ofs,
-                                    buffer,wr)) {
+                                    buffer,wr)) 
+        {
             break;
         }
 
         //set the new file length, if changed. 
-        if((this->fd_table[fd].seek + wr) > this->fd_table[fd].filesize) {
+        if((this->fd_table[fd].seek + wr) > this->fd_table[fd].filesize) 
+        {
             this->fd_table[fd].filesize = this->fd_table[fd].seek + wr;
         }
 
@@ -649,9 +682,11 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size)
     }
 
     //change the file size if we used new pages.
-    if(newPages) {
+    if(newPages) 
+    {
         if(!this->ft_set_filesize(this->fd_table[fd].ft_entry, 
-                                   this->fd_table[fd].filesize)) {
+                                   this->fd_table[fd].filesize)) 
+        {
             return -1;
         }
     }
@@ -680,7 +715,8 @@ int MicroBitFile::remove(char const * filename)
    
     // Get the FileTableEntry to remove.
     FileTableEntry* m = this->ft_by_name(filename);
-    if(m == NULL) {
+    if(m == NULL) 
+    {
         return 0;
     }
     

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -236,7 +236,7 @@ int MicroBitFile::mbr_pop_free_block() {
 int MicroBitFile::mbr_init(void* mbr_location, int mbr_no) {
     if(MBR_INITIALIZED()) return 0;
 
-    uBit.serial.printf("initializing mbr\n");
+    PRINTF("initializing mbr\n");
 
     this->mbr_free_loc = (mbr*)mbr_location;
     this->mbr_loc = (mbr*)mbr_location + 1;
@@ -314,7 +314,8 @@ int MicroBitFile::mbr_build() {
   * Constructor. Calls the necessary init() functions.
   */
 MicroBitFile::MicroBitFile() {
-    PRINTF("initializing.. %d\n", this->init());
+    int initialized = this->init();
+    PRINTF("initializing.. %d\n", initialized);
     memset(this->fd_table, 0x00, sizeof(tinyfs_fd) * MAX_FD);
 }
 

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -715,6 +715,7 @@ int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
         // File size has changed, update MBR.
         if(!this->mbr_set_filesize(this->fd_table[fd].mbr_entry, filesize)) {
             return -1;
+	}
     }
     return bytesWritten;
 }

--- a/source/MicroBitFile.cpp
+++ b/source/MicroBitFile.cpp
@@ -4,13 +4,6 @@
 #include "MicroBitFile.h"
 #include "MicroBitFlash.h"
 
-// Test if init()/mbr_init have been called.
-#define FS_INITIALIZED() (this->flash_start != NULL)
-#define MBR_INITIALIZED() (this->mbr_loc != NULL)
-
-// Check if a mbr pointer is within table.
-#define MBR_PTR_VALID(p) ( (p >= this->mbr_loc) && (p-this->mbr_loc)<=(this->mbr_entries-1) )
-
 #define MIN(a,b) ((a)<(b)?(a):(b))
 
 #define DEBUG 0
@@ -20,460 +13,711 @@
 #define PRINTF(...)
 #endif
 
-/*
- * Search for an MBR entry by name
- */
+/**
+  * @brief Find an MBR entry by name.
+  *
+  * @param filename name of file to search for. Must be null-terminated.
+  * @return pointer to the MBR struct if found, NULL otherwise or on error.
+  */
 mbr* MicroBitFile::mbr_by_name(char const * const filename) {
- if(!MBR_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return NULL;
-
- for(int i=0;i<this->mbr_entries;++i) {
-  if(strcmp(filename, this->mbr_loc[i].name) == 0) return &this->mbr_loc[i];
- }
- return NULL;
+    if(!MBR_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return NULL;
+   
+    for(int i=0;i<this->mbr_entries;++i) {
+        if(strcmp(filename, this->mbr_loc[i].name) == 0) {
+            return &this->mbr_loc[i];
+        }
+    }
+    return NULL;
 }
-/*
- * Find the lowest numbered available MBR entry 
- */
+
+/**
+  * @brief Get a pointer to the lowest numbered available MBR entry.
+  *
+  * @return pointer to the MBR if successful,
+  *         NULL if there are none available.
+  */
 mbr* MicroBitFile::mbr_get_free() {
- if(!MBR_INITIALIZED()) return NULL;
-
- for(int i=0;i<this->mbr_entries;++i) {
-  if(MBR_IS_FREE(this->mbr_loc[i])) return &this->mbr_loc[i];
- }
- return NULL;
+    if(!MBR_INITIALIZED()) return NULL;
+   
+    for(int i=0;i<this->mbr_entries;++i) {
+        if(MBR_IS_FREE(this->mbr_loc[i])) return &this->mbr_loc[i];
+    }
+    return NULL;
 }
 
-/*
- * Initialize an MBR entry with Filename, mark as unavailable, and 
- * set filesize = 0.
- */
+/**
+  * @brief initialize the mbr struct to a new file.
+  *
+  * Initialize the mbr struct with the given, null-terminated filename.
+  * Ths is used to add a new file to the MBR.
+  * This function also sets the file size to zero,
+  * and marks the MBR as busy.
+  *
+  * @param m the mbr struct to use fill.
+  * @param filename the null terminated filename to use.
+  * @return non-zero on success, zero on error.
+  */
 int MicroBitFile::mbr_add(mbr* m, char const * const filename) {
- if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) ||
-    !MBR_IS_FREE((*m)) || strlen(filename) > MAX_FILENAME_LEN) return 0;
+    if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) ||
+       !MBR_IS_FREE((*m)) || strlen(filename) > MAX_FILENAME_LEN) return 0;
+   
+    uint32_t t = MBR_BUSY;
+    
+    // Write the Filename.
+    if(!this->flash.flash_write((uint8_t*)m->name,
+                                (uint8_t*)filename, strlen(filename)+1)) {
+        return 0;
+    }
 
- uint32_t t = MBR_BUSY;
- if(!this->flash.flash_write((uint8_t*)m->name, (uint8_t*)filename, strlen(filename)+1) ||
-    !this->flash.flash_write((uint8_t*)&(m->flags), (uint8_t*)&t, sizeof(t))) return 0;
-
- PRINTF("Set mbr entry, filename: %s\n", filename);
- return 1;
+    // Write the flags/file size.
+    if(!this->flash.flash_write((uint8_t*)&(m->flags),
+                                (uint8_t*)&t, sizeof(t))) {
+        return 0;
+    }
+         
+    PRINTF("Set mbr entry, filename: %s\n", filename);
+    return 1;
 }
 
-/*
- * Add a data block to an MBR entry
- */
+/**
+  * @brief add a new block to an MBR entry
+  *
+  * Add the numbered block to the list of blocks in an  MBR entry.
+  * This function is used to expand the storage capacity for a file.
+  *
+  * @param m the mbr entry/struct to add too.
+  * @param blockNo the numbered block to append to the block list of a
+                    files' MBR.
+  * @return non-zero on success, zero on error.
+  */
 int MicroBitFile::mbr_add_block(mbr* m, uint8_t blockNo) {
- if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
+    if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
+   
+    // Find the lowest unused block entry.
+    int b = 0;
+    for(b=0;b<DATA_BLOCK_COUNT;b++) {
+ 
+        // The mbr_t.blocks list is terminated by 0xFF, this is the first 
+        // unallocated block.
+        if(m->blocks[b] == 0xFF) break;
 
- //find the lowest unused block entry.
- int b = 0;
- for(b=0;b<DATA_BLOCK_COUNT;b++) {
-  if(m->blocks[b] == 0xFF) break;
- }
- if(b==DATA_BLOCK_COUNT) return 0;
-
- //okay.
- return this->flash.flash_write(&(m->blocks[b]), &blockNo, 1);
+    }
+    if(b==DATA_BLOCK_COUNT) return 0;
+   
+    return this->flash.flash_write(&(m->blocks[b]), &blockNo, 1);
 }
 
-// ----------------------------------------------
-// Return block numbers in the mbr_t entry to the mbr_free_loc->blocks list.
-// Add to the beginning of the list.
-//
-// So if we have before:
-// [ ][ ][ ][4][5][6]
-//
-// Inserting '1' Will then become:
-// [ ][ ][1][4][5][6]
-// ----------------------------------------------
+
+/**
+  * @brief reset an MBR entry - remove a file from the MBR table.
+  *
+  * Reset an MBR entry, thereby removing a file from the system.
+  * This function also frees all of the blocks allocated to m,
+  * back to the list of free blocks.
+  *
+  * @param m the mbr entry/struct to remove.
+  * @return non-zero on success, zero on error.
+  */
 int MicroBitFile::mbr_remove(mbr* m) {
- if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
+    if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m)) return 0;
 
- int used=0;    // used = no. used blocks in mbr.
- for(used=0;used<DATA_BLOCK_COUNT;used++) {
-  if( m->blocks[used] == 0xFF) break;
- }
+    // ----------------------------------------------
+    // Return block numbers in the mbr entry to the mbr_free_loc->blocks list.
+    // Add to the beginning of the list.
+    //
+    // So if we have before:
+    // [ ][ ][ ][4][5][6]
+    //
+    // Inserting '1' Will then become:
+    // [ ][ ][1][4][5][6]
+    // ----------------------------------------------
+  
+    // used = no. used blocks in mbr. 
+    int used=0;    
+    for(used=0;used<DATA_BLOCK_COUNT;used++) {
+        if( m->blocks[used] == 0xFF) break;
+    }
+   
+    // Where to insert into free list.
+    int b = 0;     
+    for(b=0;b<DATA_BLOCK_COUNT;++b) {
+        if(this->mbr_free_loc->blocks[b] != 0x00) break;
+    }
+   
+    //not enough room. (this shouldn't happen)
+    if(used > b) { 
+        return 0;
+    }
+    int p = b-used;
+   
+    PRINTF("mbr removed. Name: %s, blocks: %d\n", m->filename, used);
+  
+    // Reset the free block list entries to 0xFF.
+    if(!this->flash.flash_erase_mem((uint8_t*)&this->mbr_free_loc->blocks[p],
+        used)) {
+        return 0;
+    }
 
- int b = 0;     // Where to insert into free list.
- for(b=0;b<DATA_BLOCK_COUNT;++b) {
-  if(this->mbr_free_loc->blocks[b] != 0x00) break;
- }
+    // Write each of the block numbers.   
+    for(int j=0;j<used;j++) {
+        uint8_t bl = m->blocks[j] | MBR_FREE_BLOCK_MARKER;
 
- if(used > b) { //not enough room...
-  return 0;
- }
- int p = b-used;
+        if(!this->flash.flash_write(&this->mbr_free_loc->blocks[p+j],&bl,1)) {
+            return 0;
+        }
+    }
 
- PRINTF("mbr removed. Name: %s, blocks: %d\n", m->filename, used);
+    // Erase the MBR (can then be resused.
+    if(!this->flash.flash_erase_mem((uint8_t*)m, sizeof(mbr))) {
+        return 0;
+    }
 
- if(!this->flash.flash_erase_mem((uint8_t*)&this->mbr_free_loc->blocks[p],used)) return 0;
-
- for(int j=0;j<used;j++) {
-  uint8_t bl = m->blocks[j] | MBR_FREE_BLOCK_MARKER;
-  if(!this->flash.flash_write(&this->mbr_free_loc->blocks[p+j], &bl, 1)) return 0;
- }
- return this->flash.flash_erase_mem((uint8_t*)m, sizeof(mbr));
+    return 1;
 }
 
-// ----------------------------------------------
-// Find a free block in mbr_free_loc->blocks.
-// Pop from the front of the list.
-//
-// So if we have beforehand:
-// [1][2][3][4][5][6]
-//
-// Will become:
-// [ ][2][3][4][5][6]
-// ----------------------------------------------
+/**
+  * @brief obtains and marks as busy, an unused block.
+  *
+  * The first MBR entry is reserved, and stores the list of unused blocks.
+  * Thiis function implements a stack, to pop a free block, mark as busy
+  * (subsequent calls will not find the same block), and return its number.
+  *
+  * @return block number on success, -1 on error (out of space).
+  */
 int MicroBitFile::mbr_pop_free_block() {
-  if(!MBR_INITIALIZED()) return -1;
+    if(!MBR_INITIALIZED()) return -1;
+  
+    // ----------------------------------------------
+    // Find a free block in mbr_free_loc->blocks.
+    // Pop from the front of the list.
+    //
+    // So if we have beforehand:
+    // [1][2][3][4][5][6]
+    //
+    // Will become:
+    // [ ][2][3][4][5][6]
+    // ----------------------------------------------
+  
+    //find the lowest free block.
+    int b = 0;
+    for(b=0;b<DATA_BLOCK_COUNT;b++) {
+         if(this->mbr_free_loc->blocks[b] != 0x00 &&
+            this->mbr_free_loc->blocks[b] != 0xFF) break;
+    }
+    if(b==DATA_BLOCK_COUNT) {
+        PRINTF("No free blocks available\n");
+        return -1;
+    }
+  
+    //mark as unavailable in the free block list.
+    uint8_t write_empty = 0x00;
+    uint8_t blockNumber = mbr_get_block(this->mbr_free_loc, b);
+    blockNumber &= ~(MBR_FREE_BLOCK_MARKER);
 
-  //find the lowest free block.
-  int b = 0;
-  for(b=0;b<DATA_BLOCK_COUNT;b++) {
-   if(this->mbr_free_loc->blocks[b] != 0x00 &&
-      this->mbr_free_loc->blocks[b] != 0xFF) break;
-  }
-  if(b==DATA_BLOCK_COUNT) {
-    PRINTF("No free blocks available\n");
-    return -1;
-  }
-
-  //mark as unavailable.
-  uint8_t write_empty = 0x00;
-  uint8_t blockNumber = this->mbr_free_loc->blocks[b] &= ~(MBR_FREE_BLOCK_MARKER);
-  if(!this->flash.flash_write(&this->mbr_free_loc->blocks[b], &write_empty, 1)) return -1;
-
-  PRINTF("Free block %d from location in list %d\n", blockNumber, b);
-  return blockNumber;
+    if(!this->flash.flash_write(&this->mbr_free_loc->blocks[b], 
+                                &write_empty, 1)) return -1;
+  
+    PRINTF("Free block %d from location in list %d\n", blockNumber, b);
+    return blockNumber;
 }
 
-/*
- * Initialize the MBR functions, with pointers to the MBR page in flash.
+/**
+  * @brief initialize the MBR API.
+  *
+  * This function initializes the API for subsequent calls,
+  * particularly storing the flash location, and number of entries.
+  * This function must be called before any other.
+  *
+  * @param mbr_location Location in flash of where to store the MBR.
+  * @param mbr_entries The number of entries in the MBR
+  *                    (hence determining the max no. files).
+  * @return non-zero on success, zero on error.
  */
 int MicroBitFile::mbr_init(void* mbr_location, int mbr_no) {
-  if(MBR_INITIALIZED()) return 0;
-  uBit.serial.printf("initializing mbr\n");
-  this->mbr_free_loc = (mbr*)mbr_location;
-  this->mbr_loc = (mbr*)mbr_location + 1;
-  this->mbr_entries = mbr_no-1;
-  return 1;
-}
+    if(MBR_INITIALIZED()) return 0;
 
-/*
- * Set the filesize attribute of an MBR entry 
- */
-int MicroBitFile::mbr_set_filesize(mbr* m, uint32_t fz) {
-  if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) || MBR_IS_FREE(*m)) return 0;
+    uBit.serial.printf("initializing mbr\n");
 
-  PRINTF("set filesize: %s to %d bytes\n", m->name, fz);
-  return this->flash.flash_write((uint8_t*)&m->flags, (uint8_t*)&fz, 4);
-}
+    this->mbr_free_loc = (mbr*)mbr_location;
+    this->mbr_loc = (mbr*)mbr_location + 1;
+    this->mbr_entries = mbr_no-1;
 
-/*
- * Check if the Master Boot Record (MBR) table has already been initialized.
- * Initialize if not.
- */
-int MicroBitFile::mbr_build() {
-  if(!MBR_INITIALIZED()) return 0;
-
-  // Only build the MBR table if not already initialized...
-  if(*((uint32_t*)this->mbr_free_loc) == MAGIC_WORD) {
-    uBit.serial.printf("Magic word detected, file system already built\n");
     return 1;
-  }
-  uBit.serial.printf("Magic word not detected, building file system\n");
-
-  uint32_t magic = MAGIC_WORD;
-
-  // Erase MBR Page.
-  if(!this->flash.flash_erase_mem((uint8_t*)this->mbr_free_loc, PAGE_SIZE)) return 0;
-
-  // Write Magic.
-  if(!this->flash.flash_write((uint8_t*)this->mbr_free_loc->name,
-                  (uint8_t*)&magic, sizeof(magic))) return 0;
-
-
-  // Write Free data blocks.
-  uint8_t bl[DATA_BLOCK_COUNT-1];
-  for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) bl[i] = i | MBR_FREE_BLOCK_MARKER;
-
-  return this->flash.flash_write((uint8_t*)&this->mbr_free_loc->blocks, bl, DATA_BLOCK_COUNT-1);
 }
 
-/*
- * Constructor
- */
-MicroBitFile::MicroBitFile() {
- uBit.serial.printf("initializing.. %d\n", this->init());
- memset(this->fd_table, 0x00, sizeof(tinyfs_fd) * MAX_FD);
-}
-
-/*
- * Init function, call mbr_init and mbr_build, store the flash memory location.
- */
-int MicroBitFile::init() {
- if(FS_INITIALIZED()) return 0;
-
- if(!this->mbr_init((uint8_t*)FLASH_START, NO_MBR_ENTRIES)) return 0;
-
- if(!this->mbr_build()) return 0;
-
- uBit.serial.printf("initialized\n");
+/**
+  * @brief set the filesize of an mbr
+  *
+  * Set, in the MBR, the filesize of the entry, m.
+  *
+  * @param m the MBR entry/file to modify
+  * @param filesize the new filesize.
+  * @return non-zero on success, zero on error.
+  */
+int MicroBitFile::mbr_set_filesize(mbr* m, uint32_t fz) {
+    if(!MBR_INITIALIZED() || !MBR_PTR_VALID(m) || MBR_IS_FREE(*m)) return 0;
   
- this->flash_start = (uint8_t*)FLASH_START + PAGE_SIZE;
- this->flash_pages = NO_MBR_ENTRIES-1;
- return 1;
+    PRINTF("set filesize: %s to %d bytes\n", m->name, fz);
+    return this->flash.flash_write((uint8_t*)&m->flags, (uint8_t*)&fz, 4);
 }
 
-/*
- * Open a file, and obtain a file handle.
- */
+/**
+  * @brief reset the MBR.
+  *
+  * The MBR must be in an initial state for it to work.
+  * Namely, all of the mbr entries must be set to empty (0xFF).
+  * and the stack of unused blocks must be populated.
+  *
+  * This function also sets the MAGIC_WORD as the first word in
+  * the MBR block, used to determine if the MBR has already been
+  * configured.
+  *
+  * This function should be called from the init() function.
+  *
+  * @return non-zero on success, zero otherwise.
+  */
+int MicroBitFile::mbr_build() {
+    if(!MBR_INITIALIZED()) return 0;
+  
+    // Only build the MBR table if not already initialized.
+    if(*((uint32_t*)this->mbr_free_loc) == MAGIC_WORD) {
+        PRINTF("Magic word detected, file system already built\n");
+        return 1;
+    }
+    PRINTF("Magic word not detected, building file system\n");
+  
+    uint32_t magic = MAGIC_WORD;
+  
+    // Erase MBR Page.
+    if(!this->flash.flash_erase_mem((uint8_t*)this->mbr_free_loc, PAGE_SIZE)) {
+        return 0;
+    }
+  
+    // Write Magic.
+    if(!this->flash.flash_write((uint8_t*)this->mbr_free_loc->name,
+                                (uint8_t*)&magic, sizeof(magic))) {
+        return 0;
+    }
+  
+  
+    // Populate the free block list.
+    uint8_t bl[DATA_BLOCK_COUNT-1];
+    for(int i=0;i<(DATA_BLOCK_COUNT-1);++i) {
+        bl[i] = i | MBR_FREE_BLOCK_MARKER;
+    }
+  
+    return this->flash.flash_write((uint8_t*)&this->mbr_free_loc->blocks, 
+                                    bl, DATA_BLOCK_COUNT-1);
+}
+
+/**
+  * Constructor. Calls the necessary init() functions.
+  */
+MicroBitFile::MicroBitFile() {
+    PRINTF("initializing.. %d\n", this->init());
+    memset(this->fd_table, 0x00, sizeof(tinyfs_fd) * MAX_FD);
+}
+
+/**
+  * @brief Initialize the flash storage system
+  *
+  * This method:
+  * - calls mbr_init().
+  * - stores the location of the flash memory.
+  * - calls mbr_build()
+  *
+  * @return non-zero on success, zero on error.
+  */
+int MicroBitFile::init() {
+    if(FS_INITIALIZED()) return 0;
+
+    // MBR-specific init/build.   
+    if(!this->mbr_init((uint8_t*)FLASH_START, NO_MBR_ENTRIES)) return 0;
+    if(!this->mbr_build()) return 0;
+   
+    PRINTF("initialized\n");
+     
+    this->flash_start = (uint8_t*)FLASH_START + PAGE_SIZE;
+    this->flash_pages = NO_MBR_ENTRIES-1;
+
+    return 1;
+}
+
+/**
+  * Open a new file, and obtain a new file handle (int) to
+  * read/write/seek the file. The flags are:
+  *  - MB_READ : read from the file.
+  *  - MB_WRITE : write to the file.
+  *  - MB_CREAT : create a new file, if it doesn't already exist.
+  *
+  * If a file is opened that doesn't exist, and MB_CREAT isn't passed,
+  * an error is returned, otherwise the file is created.
+  * If the seek pointer is set beyond the current end of the file,
+  * which is then written to, the file is padded with 0x00.
+  *
+  * @todo The same file can only be opened by a single handle at once.
+  * @todo Add MB_APPEND flag.
+  *
+  * @param filename name of the file to open, must be null terminated.
+  * @param flags
+  * @return return the file handle, >= 0, or < 0 on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFile f();
+  * int fd = f.open("test.txt", MB_WRITE|MB_CREAT);
+  * if(fd<0)
+  *    print("file open error");
+  * @endcode
+  */
 int MicroBitFile::open(char const * const filename, uint8_t flags) {
- if(!FS_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return -1;
+    if(!FS_INITIALIZED() || strlen(filename) > MAX_FILENAME_LEN) return -1;
+   
+    mbr* m;
+    int fd;
+   
+    //find the file, if it already exists.
+    if((m = this->mbr_by_name(filename)) == NULL) {
 
- mbr* m;
- int fd;
+        // File doesn't exist, try to create it.
+        if((flags & MB_CREAT) != MB_CREAT || 
+           (m = this->mbr_get_free()) == NULL || 
+           !this->mbr_add(m, filename)) {
 
- //find, or create, the file.
- if((m = this->mbr_by_name(filename)) == NULL) {
-  if((flags & MB_CREAT) != MB_CREAT || 
-     (m = this->mbr_get_free()) == NULL || 
-     !this->mbr_add(m, filename)) return -1;
-
-  PRINTF("open: file created %s\n", filename);
- }
-
- //find a free FD.
- for(fd=0;fd<MAX_FD;fd++) {
-  if((this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) break;
- }
- if(fd == MAX_FD) {
-   return -1;
-   PRINTF("No free FDs\n");
- }
-
- //populate the fd.
- this->fd_table[fd].flags = (flags & ~(MB_CREAT)) | MB_FD_BUSY;
- this->fd_table[fd].mbr_entry = m;
- this->fd_table[fd].seek = 0;
- return fd;
+            // Couldn't set the MBR entry.
+            return -1;
+        }
+   
+        PRINTF("open: file created %s\n", filename);
+    }
+   
+    //find a free FD.
+    for(fd=0;fd<MAX_FD;fd++) {
+        if((this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) break;
+    }
+    if(fd == MAX_FD) {
+        return -1;
+        PRINTF("No free FDs\n");
+    }
+   
+    //populate the fd.
+    this->fd_table[fd].flags = (flags & ~(MB_CREAT)) | MB_FD_BUSY;
+    this->fd_table[fd].mbr_entry = m;
+    this->fd_table[fd].seek = 0;
+    return fd;
 }
 
-/*
- * Close file handle, FD available for re-use.
- */
+/**
+  * Close the specified file handle.
+  * File handle resources are then made available for future open() calls.
+  *
+  * @param fd file descriptor - obtained with open().
+  * @return non-zero on success, zero on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFile f();
+  * int fd = f.open("test.txt", MB_READ);
+  * if(!f.close(fd))
+  *    print("error closing file.");
+  * @endcode
+  */
 int MicroBitFile::close(int fd) {
- if(!FS_INITIALIZED() ||
-   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return 0;
+    if(!FS_INITIALIZED() ||
+      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return 0;
 
- this->fd_table[fd].flags = 0x00;
- return 1;
+    this->fd_table[fd].flags = 0x00;
+    return 1;
 }
 
-/*
- * Seek to a set position in the file
- */
+/**
+  * Move the current position of a file handle, to be used for
+  * subsequent read/write calls.
+  *
+  * The offset modifier can be:
+  *  - MB_SEEK_SET set the absolute seek position.
+  *  - MB_SEEK_CUR set the seek position based on the current offset.
+  *  - MB_SEEK_END set the seek position from the end of the file.
+  * E.g. to seek to 2nd-to-last byte, use offset=-1.
+  *
+  * @param fd file handle, obtained with open()
+  * @param offset new offset, can be positive/negative.
+  * @param flags
+  * @return new offset position on success, < 0 on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFile f;
+  * int fd = f.open("test.txt", MB_READ);
+  * f.seek(fd, -100, MB_SEEK_END); //100 bytes before end of file.
+  * @endcode
+  */
 int MicroBitFile::seek(int fd, int offset, uint8_t flags) {
- if(!FS_INITIALIZED() ||
-   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return -1;
- 
- int32_t new_pos = 0;
- int max_size = mbr_get_filesize(this->fd_table[fd].mbr_entry);
-
- if(flags == MB_SEEK_SET && offset <= max_size) {
-   new_pos = offset;
- }
- else if(flags == MB_SEEK_END && offset <= max_size) {
-   new_pos = max_size+offset;
- }
- else if(flags == MB_SEEK_CUR && (this->fd_table[fd].seek+offset) <= max_size) {
-   new_pos = this->fd_table[fd].seek + offset;
- }
- else {
-  PRINTF("seek range error, offset %d, flag %d, fd %dn", offset, flags, fd);
-  return -1;
- }
-
- this->fd_table[fd].seek = new_pos;
- return new_pos;
+    if(!FS_INITIALIZED() ||
+      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY) return -1;
+    
+    int32_t new_pos = 0;
+    int max_size = mbr_get_filesize(this->fd_table[fd].mbr_entry);
+   
+    if(flags == MB_SEEK_SET && offset <= max_size) {
+        new_pos = offset;
+    }
+    else if(flags == MB_SEEK_END && offset <= max_size) {
+        new_pos = max_size+offset;
+    }
+    else if(flags == MB_SEEK_CUR && 
+           (this->fd_table[fd].seek+offset) <= max_size) {
+        new_pos = this->fd_table[fd].seek + offset;
+    }
+    else {
+        PRINTF("seek range error, offset %d, flag %d, fd %dn", 
+               offset, flags, fd);
+        return -1;
+    }  
+   
+    this->fd_table[fd].seek = new_pos;
+    return new_pos;
 }
 
-// Basic algorithm:
-// Find the starting block number & offset,
-//
-//  blockInd = starting block index in list
-//  blockOffset = offset within first block
-// 
-//  while [still have bytes to read
-//   b = block number (from blockInd)
-//   s = how many bytes to read from this block
-//   if(s > bytes remaining in file)
-//    s = bytes remaining in file
-//   end
-// 
-//   memcpy(destination buffer, this->flash_start + (b * PAGE_SIZE) + blockOffset)
-//   seek += s
-//   bytesRead += s 
-//   blockOffset = 0
-//   blockInd++
-//  end
-//
-//  return bytesRead
-//
+/**
+  * Read data from the file.
+  *
+  * Read len bytes from the current seek position in the file, into the buffer.
+  * On each invocation to read, the seek position of the file handle
+  * is incremented atomically, by the number of bytes returned.
+  *
+  * @param fd File handle, obtained with open()
+  * @param buffer to store data
+  * @param len number of bytes to read
+  * @return number of bytes read on success, < 0 on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFile f;
+  * int fd = f.open("read.txt", MB_READ);
+  * if(f.read(fd, buffer, 100) != 100)
+  *    print("read error");
+  * @endcode
+  */
 int MicroBitFile::read(int fd, uint8_t* buffer, int size) {
- if(!FS_INITIALIZED() ||
-   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
-   (this->fd_table[fd].flags & MB_READ) != MB_READ) return -1;
+    if(!FS_INITIALIZED() ||
+      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
+      (this->fd_table[fd].flags & MB_READ) != MB_READ) return -1;
+   
+    // Basic algorithm:
+    // Find the starting block number & offset,
+    //
+    //  blockInd = starting block index in list
+    //  blockOffset = offset within first block
+    // 
+    //  while [still have bytes to read
+    //   b = block number (from blockInd)
+    //   s = how many bytes to read from this block
+    //   if(s > bytes remaining in file)
+    //    s = bytes remaining in file
+    //   end
+    // 
+    //   memcpy(destination buffer, this->flash_start 
+    //      + (b * PAGE_SIZE) + blockOffset)
+    //   seek += s
+    //   bytesRead += s 
+    //   blockOffset = 0
+    //   blockInd++
+    //  end
+    //
+    //  return bytesRead
+    //
+   
+    int blockInd = this->fd_table[fd].seek / PAGE_SIZE;
+    int blockOffset = this->fd_table[fd].seek % PAGE_SIZE;
+    int32_t filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry);
+    int bytesRead = 0;
+  
+    // Write until requested number of bytes have been read. 
+    for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) {
+  
+        // b = block number 
+        int b = mbr_get_block(this->fd_table[fd].mbr_entry, blockInd);
 
- int blockInd = this->fd_table[fd].seek / PAGE_SIZE;
- int blockOffset = this->fd_table[fd].seek % PAGE_SIZE;
- int32_t filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry);
- int bytesRead = 0;
+        // s = no. bytes to read from this page.
+        int s = MIN(PAGE_SIZE-blockOffset,sz);
 
- for(int sz = size;sz > 0 && this->fd_table[fd].seek<filesize;) {
-
-  int b = mbr_get_block(this->fd_table[fd].mbr_entry, blockInd);
-  int s = MIN(PAGE_SIZE-blockOffset,sz);
-  if((this->fd_table[fd].seek+s) > filesize) {
-   s = filesize - this->fd_table[fd].seek;
-  }
-
-  PRINTF("Read %d bytes from block %d (%d) offset: %d\n",
-	s, blockInd, b, s, blockOffset);
-
-  memcpy( buffer, this->flash_start + (PAGE_SIZE * b) + blockOffset, s);
- 
-  sz -= s;
-  buffer += s;
-  blockInd++;
-  blockOffset=0;
-  this->fd_table[fd].seek += s;
-  bytesRead += s;
- }
-
- return bytesRead;
+        // Can't read beyond the end of the file.
+        if((this->fd_table[fd].seek+s) > filesize) {
+         s = filesize - this->fd_table[fd].seek;
+        }
+   
+        PRINTF("Read %d bytes from block %d (%d) offset: %d\n",
+   	            s, blockInd, b, s, blockOffset);
+   
+        memcpy( buffer, this->flash_start + (PAGE_SIZE * b) + blockOffset, s);
+    
+        sz -= s;
+        buffer += s;
+        blockInd++;
+        blockOffset=0;
+        this->fd_table[fd].seek += s;
+        bytesRead += s;
+    }
+   
+    return bytesRead;
 }
 
-// More complex than tfs_read(), because we have to account for the
-// file increasing in size, and padding 0x00 if starting past current end.
-// 
-// allocated_blocks = current no. allocated blocks to mbr
-// 
-// while still data to write
-//  if(seek extends beyond current file size)
-//   bInd = final block in file
-//   ofs = current end-offset in last block
-//   wr = how many bytes to write 0x00 to
-//   writeData = false (don't write data on this iteration, just fill 0x00)
-//  else
-//   bInd = block Index to start writing.
-//   ofs = offset within block
-//   wr = number of bytes to write.
-//   writeData = true (write data from buffer on this iteration)
-//  end
-// 
-//  if(bInd >= allocated_blocks)
-//   b = pop_free_block()
-//   add_block(b)
-//  else
-//   b = get_block(bInd)
-//  end
-// 
-//  if(writeData)
-//   write to(this->flash_start + PAGE_SIZE * b + ofs, buffer, wr)
-//  else
-//   flash_memset(this->flash_start + PAGE_SIZE + b + ofs, 0x00, wr)
-//  end
-// 
-//  bytesWritten += wr
-//  bInd++
-// 
-//  return bytesWritten
-//  
+
+/**
+  * Write data to the file.
+  *
+  * Write from buffer, len bytes to the current seek position.
+  * On each invocation to write, the seek position of the file handle
+  * is incremented atomically, by the number of bytes returned.
+  *
+  * @param fd File handle
+  * @param buffer the buffer from which to write data
+  * @param len number of bytes to write
+  * @return number of bytes written on success, < 0 on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFile f();
+  * int fd = f.open("test.txt", MB_WRITE);
+  * if(f.write(fd, "hello!", 7) != 7)
+       print("error writing");
+  * @endcode
+  */
 int MicroBitFile::write(int fd, uint8_t* buffer, int size) {
- if(!FS_INITIALIZED() ||
-   (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
-   (this->fd_table[fd].flags & MB_WRITE) != MB_WRITE) return -1;
-
- int bInd; //block index
- int b; //absolute block number to write.
- int ofs; //offset within block to write.
- int wr; //no. bytes to write on a pass.
- 
- int bytesWritten = 0;
- int writeData; //flag: 1=write data, 0=pad 0x00.
-
- int filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry); 
- int origSize = filesize;
-
- int allocated_blocks = filesize / PAGE_SIZE; //current no. blocks assigned.
- if( (filesize % PAGE_SIZE) != 0) allocated_blocks++;
-
- for(int sz = size;sz > 0;) {
-
-  if(this->fd_table[fd].seek > filesize) {
-   bInd = (filesize) / PAGE_SIZE;
-   ofs = (filesize) % PAGE_SIZE;
-   wr = MIN(PAGE_SIZE-ofs, this->fd_table[fd].seek-filesize);
-   writeData = 0;
-  }
-  else { //starting beyond current file end, pad 0x00.
-   bInd = this->fd_table[fd].seek / PAGE_SIZE;
-   ofs = this->fd_table[fd].seek % PAGE_SIZE;
-   wr = MIN(PAGE_SIZE-ofs,sz);
-   writeData = 1;
-  }
- 
-  if(bInd >= allocated_blocks) { // Get the block number, or allocate one.
-   if( (b = this->mbr_pop_free_block()) < 0 || 
-      ! this->mbr_add_block(this->fd_table[fd].mbr_entry, b) ) break;
-
-   allocated_blocks++;
-   PRINTF("New block allocated: %d\n", b);
-  }
-  else {
-   b = mbr_get_block(this->fd_table[fd].mbr_entry, bInd);
-  } 
-
-  PRINTF("Write %s block index %d, number %d, offset %d, length %d\n",
-         (writeData?"data":"0x00"), bInd, b, ofs, wr);
-
-  if(writeData) { //write data from buffer.
-   if(!this->flash.flash_write( this->flash_start + (PAGE_SIZE * b) + ofs, buffer, wr)) break;
-   if((this->fd_table[fd].seek + wr) > filesize) { //set the new file length
-    filesize = this->fd_table[fd].seek + wr;
-   }
-
-   sz -= wr; 
-   buffer += wr;
-   this->fd_table[fd].seek += wr;
-  }
-  else { //write 0x00 to pad.
-   if(!this->flash.flash_memset( this->flash_start + (PAGE_SIZE * b) + ofs, 0x00, wr)) break;
-   filesize += wr; //set the new file length.
-  }
-
-  bytesWritten += wr;
- }
-
- if(origSize != filesize) {
-   if(!this->mbr_set_filesize(this->fd_table[fd].mbr_entry, filesize))return -1;
- }
- return bytesWritten;
+    if(!FS_INITIALIZED() ||
+      (this->fd_table[fd].flags & MB_FD_BUSY) != MB_FD_BUSY ||
+      (this->fd_table[fd].flags & MB_WRITE) != MB_WRITE) return -1;
+   
+    // More complex than tfs_read(), because we have to account for the
+    // file increasing in size, and padding 0x00 if starting past current end.
+    // 
+    // allocated_blocks = current no. allocated blocks to mbr
+    // 
+    // while still data to write
+    //  if(seek extends beyond current file size)
+    //   bInd = final block in file
+    //   ofs = current end-offset in last block
+    //   wr = how many bytes to write 0x00 to
+    //   writeData = false (don't write data on this iteration, just fill 0x00)
+    //  else
+    //   bInd = block Index to start writing.
+    //   ofs = offset within block
+    //   wr = number of bytes to write.
+    //   writeData = true (write data from buffer on this iteration)
+    //  end
+    // 
+    //  if(bInd >= allocated_blocks)
+    //   b = pop_free_block()
+    //   add_block(b)
+    //  else
+    //   b = get_block(bInd)
+    //  end
+    // 
+    //  if(writeData)
+    //   write to(this->flash_start + PAGE_SIZE * b + ofs, buffer, wr)
+    //  else
+    //   flash_memset(this->flash_start + PAGE_SIZE + b + ofs, 0x00, wr)
+    //  end
+    // 
+    //  bytesWritten += wr
+    //  bInd++
+    // 
+    //  return bytesWritten
+    //  
+   
+    int bInd; //block index
+    int b; //absolute block number to write.
+    int ofs; //offset within block to write.
+    int wr; //no. bytes to write on a pass.
+    
+    int bytesWritten = 0;
+    int writeData; //flag: 1=write data, 0=pad 0x00.
+   
+    int filesize = mbr_get_filesize(this->fd_table[fd].mbr_entry); 
+    int origSize = filesize;
+   
+    int allocated_blocks = filesize / PAGE_SIZE; //current no. blocks assigned.
+    if( (filesize % PAGE_SIZE) != 0) allocated_blocks++;
+   
+    for(int sz = size;sz > 0;) {
+   
+     if(this->fd_table[fd].seek > filesize) {
+      bInd = (filesize) / PAGE_SIZE;
+      ofs = (filesize) % PAGE_SIZE;
+      wr = MIN(PAGE_SIZE-ofs, this->fd_table[fd].seek-filesize);
+      writeData = 0;
+     }
+     else { //starting beyond current file end, pad 0x00.
+      bInd = this->fd_table[fd].seek / PAGE_SIZE;
+      ofs = this->fd_table[fd].seek % PAGE_SIZE;
+      wr = MIN(PAGE_SIZE-ofs,sz);
+      writeData = 1;
+     }
+    
+     if(bInd >= allocated_blocks) { // Get the block number, or allocate one.
+      if( (b = this->mbr_pop_free_block()) < 0 || 
+         ! this->mbr_add_block(this->fd_table[fd].mbr_entry, b) ) break;
+   
+      allocated_blocks++;
+      PRINTF("New block allocated: %d\n", b);
+     }
+     else {
+      b = mbr_get_block(this->fd_table[fd].mbr_entry, bInd);
+     } 
+   
+     PRINTF("Write %s block index %d, number %d, offset %d, length %d\n",
+            (writeData?"data":"0x00"), bInd, b, ofs, wr);
+   
+     if(writeData) { //write data from buffer.
+      if(!this->flash.flash_write( this->flash_start + (PAGE_SIZE * b) + ofs, buffer, wr)) break;
+      if((this->fd_table[fd].seek + wr) > filesize) { //set the new file length
+       filesize = this->fd_table[fd].seek + wr;
+      }
+   
+      sz -= wr; 
+      buffer += wr;
+      this->fd_table[fd].seek += wr;
+     }
+     else { //write 0x00 to pad.
+      if(!this->flash.flash_memset( this->flash_start + (PAGE_SIZE * b) + ofs, 0x00, wr)) break;
+      filesize += wr; //set the new file length.
+     }
+   
+     bytesWritten += wr;
+    }
+   
+    if(origSize != filesize) {
+      if(!this->mbr_set_filesize(this->fd_table[fd].mbr_entry, filesize))return -1;
+    }
+    return bytesWritten;
 }
 
-/*
- * Delete a file. This deletes atomically.
- */ 
+/**
+  * Remove a file from the system, and free allocated assets
+  * (including assigned blocks which are returned for use by other files).
+  *
+  * @todo the file must not already have an open file handle.
+  *
+  * @param filename null-terminated name of the file to remove.
+  * @return non-zero on success, zero on error
+  *
+  * Example:
+  * @code
+  * MicroBitFile f;
+  * if(!f.unlink("file.txt"))
+  *     print("file could not be deleted")
+  * @endcode
+  */
 int MicroBitFile::unlink(char const * const filename) {
- if(!FS_INITIALIZED()) return 0;
-
- mbr* m = this->mbr_by_name(filename);
- if(m == NULL) {
-  PRINTF("cannot unlink %s, not found\n", filename);
-  return 0;
- }
- 
- return this->mbr_remove(m);
+    if(!FS_INITIALIZED()) return 0;
+   
+    // Get the mbr to remove.
+    mbr* m = this->mbr_by_name(filename);
+    if(m == NULL) {
+        PRINTF("cannot unlink %s, not found\n", filename);
+        return 0;
+    }
+    
+    return this->mbr_remove(m);
 }

--- a/source/MicroBitFlash.cpp
+++ b/source/MicroBitFlash.cpp
@@ -1,6 +1,6 @@
 #include "MicroBit.h"
 #include "MicroBitFlash.h"
-#include "tinyfs_config.h"
+#include "MicroBitFile_config.h"
 
 #define WORD_ADDR(x) (((uint32_t)x) & 0xFFFFFFFC)
 #define MIN(a,b) (a<b?a:b)

--- a/source/MicroBitFlash.cpp
+++ b/source/MicroBitFlash.cpp
@@ -29,7 +29,8 @@ int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len)
     // O & ~N != 0
     // Where O = original, and N = new byte.
 
-    for(;len>0;len--) {
+    for(;len>0;len--) 
+    {
         if((~*(flash_addr++) & *(source++)) != 0x00) return 1;
     }
     return 0;
@@ -52,7 +53,7 @@ void MicroBitFlash::erase_page(uint32_t* pg_addr)
 
     // Turn off flash erase enable and wait until the NVMC is ready:
     NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
-    while (NRF_NVMC->READY == NVMC_READY_READY_Busy);
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
 }
  
 /**
@@ -71,7 +72,8 @@ void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size)
     NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
     while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
  
-    for(int i=0;i<size;i++) {
+    for(int i=0;i<size;i++) 
+    {
         *(addr+i) = *(buffer+i);
         while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
     }
@@ -119,7 +121,8 @@ int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
     int start = WORD_ADDR(offset);
     int end = WORD_ADDR((offset+length+4));
 
-    if(need_erase(from_buffer, address, length)) {
+    if(need_erase(from_buffer, address, length)) 
+    {
         this->erase_page((uint32_t*)SCRATCH_PAGE_ADDR);
         this->flash_burn((uint32_t*)SCRATCH_PAGE_ADDR, pgAddr, PAGE_SIZE/4);
         this->erase_page(pgAddr);
@@ -130,24 +133,30 @@ int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
 
     uint32_t writeWord = 0;
 
-    for(int i=start;i<end;i++) {
+    for(int i=start;i<end;i++) 
+    {
         int byteOffset = i%4;
 
-        if(i >= offset && i < (offset + length)) {
-            if(m == WR_WRITE) {
+        if(i >= offset && i < (offset + length)) 
+        {
+            if(m == WR_WRITE) 
+            {
                 // Write from buffer.
                 writeWord |= (from_buffer[i-offset] << ((byteOffset)*8));
             }
-            else if(m == WR_MEMSET) {
+            else if(m == WR_MEMSET) 
+            {
                 // Write constant.
                 writeWord |= ((uint32_t)write_byte << (byteOffset*8));
             }
         }
-        else {
+        else 
+        {
             writeWord |= (writeFrom[i] << ((byteOffset)*8));
         }
 
-        if( ((i+1)%4) == 0) {
+        if( ((i+1)%4) == 0) 
+        {
             this->flash_burn(pgAddr + (i/4), &writeWord, 1);
             writeWord = 0;
         }

--- a/source/MicroBitFlash.cpp
+++ b/source/MicroBitFlash.cpp
@@ -1,0 +1,122 @@
+#include "MicroBit.h"
+#include "MicroBitFlash.h"
+#include "tinyfs_config.h"
+
+#define WORD_ADDR(x) (((uint32_t)x) & 0xFFFFFFFC)
+#define MIN(a,b) (a<b?a:b)
+
+MicroBitFlash::MicroBitFlash() {
+  this->flash_start = (uint32_t*)FLASH_START;
+}
+
+// Erase is necessary if for any byte:
+// O & ~N != 0
+// Where O = original, and N = new byte.
+int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len) {
+  for(;len>0;len--) {
+    if((~*(flash_addr++) & *(source++)) != 0x00) return 1;
+  }
+  return 0;
+}
+
+// Erase an entire page. pg_addr must be first word of page.
+void MicroBitFlash::erase_page(uint32_t* pg_addr) {
+  //uBit.serial.printf("erase_page %d 0x%x\n", ((uint32_t)pg_addr / 256), pg_addr);
+
+  // Turn on flash erase enable and wait until the NVMC is ready:
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een);
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
+
+  // Erase page:
+  NRF_NVMC->ERASEPAGE = (uint32_t)pg_addr;
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
+
+  // Turn off flash erase enable and wait until the NVMC is ready:
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy);
+}
+ 
+// Assumes that this is valid under flash writing rules (see erase_page).
+void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size) {
+  //uBit.serial.printf("flash_burn page %d 0x%x, from 0x%x, size %d\n",
+  //     ((uint32_t)addr / 256), addr, buffer, size);
+ 
+  // Turn on flash write enable and wait until the NVMC is ready:
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
+ 
+  for(int i=0;i<size;i++) {
+    *(addr+i) = *(buffer+i);
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
+  }
+ 
+  // Turn off flash write enable and wait until the NVMC is ready:
+  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
+}
+ 
+// Generic function for burning unaligned data, to unaligned flash addresses.
+// Can come from a buffer, or a preset byte value, determined by flash_mode m
+int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
+	uint8_t write_byte, int length, flash_mode m) {
+
+  // page number.
+  int page = (address - (uint8_t*)flash_start) / PAGE_SIZE;
+
+  //page address.
+  uint32_t* pgAddr = flash_start + (page * (PAGE_SIZE/sizeof(uint32_t)));
+
+  // offset to write from within page.
+  int offset = (address - (uint8_t*)flash_start) % (int)PAGE_SIZE;
+
+  // uBit.serial.printf("flash_write to 0x%x, from 0x%x, length: 0x%x\n",
+  //       	     address, from_buffer, length);
+  // uBit.serial.printf(" - offset = %d, pgAddr = 0x%x, page = %d\n",
+  //                    offset, pgAddr, page);
+
+  uint8_t* writeFrom = (uint8_t*)pgAddr;
+  int start = WORD_ADDR(offset);
+  int end = WORD_ADDR((offset+length+4));
+
+  if(need_erase(from_buffer, address, length)) {
+    this->erase_page((uint32_t*)SCRATCH_PAGE_ADDR);
+    this->flash_burn((uint32_t*)SCRATCH_PAGE_ADDR, pgAddr, PAGE_SIZE/4);
+    this->erase_page(pgAddr);
+    writeFrom = (uint8_t*)SCRATCH_PAGE_ADDR;
+    start = 0;
+    end = PAGE_SIZE;
+  }
+
+  uint32_t writeWord = 0;
+
+  for(int i=start;i<end;i++) {
+    int byteOffset = i%4;
+
+    if(i >= offset && i < (offset + length)) {
+      if(m == WR_WRITE) writeWord |= (from_buffer[i-offset] << ((byteOffset)*8));
+      else if(m == WR_MEMSET) writeWord |= ((uint32_t)write_byte << (byteOffset*8));
+    }
+    else {
+      writeWord |= (writeFrom[i] << ((byteOffset)*8));
+    }
+
+    if( ((i+1)%4) == 0) {
+      this->flash_burn(pgAddr + (i/4), &writeWord, 1);
+      writeWord = 0;
+    }
+
+  }
+
+  return 1;
+}
+
+int MicroBitFlash::flash_write(uint8_t* address, uint8_t* from_buffer, int length) {
+ return this->flash_write_mem(address, from_buffer, 0, length, WR_WRITE);
+}
+int MicroBitFlash::flash_memset(uint8_t* address, uint8_t write_byte, int length) {
+ return this->flash_write_mem(address, NULL, write_byte, length, WR_MEMSET);
+}
+int MicroBitFlash::flash_erase_mem(uint8_t* address, int length) {
+ return this->flash_write_mem(address, NULL, 0xFF, length, WR_MEMSET);
+}
+

--- a/source/MicroBitFlash.cpp
+++ b/source/MicroBitFlash.cpp
@@ -5,118 +5,205 @@
 #define WORD_ADDR(x) (((uint32_t)x) & 0xFFFFFFFC)
 #define MIN(a,b) (a<b?a:b)
 
+/**
+  * Default Constructor
+  */
 MicroBitFlash::MicroBitFlash() {
   this->flash_start = (uint32_t*)FLASH_START;
 }
 
-// Erase is necessary if for any byte:
-// O & ~N != 0
-// Where O = original, and N = new byte.
+/**
+  * Check if an erase is required to write to a region in flash memory.
+  * This is determined if, for any byte:
+  * ~O & N != 0x00
+  * Where O=Original byte, N = New byte.
+  *
+  * @param source to write from
+  * @param flash_address to write to
+  * @param len number of uint8_t to check.
+  * @return non-zero if erase required, zero otherwise.
+  */
 int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len) {
-  for(;len>0;len--) {
-    if((~*(flash_addr++) & *(source++)) != 0x00) return 1;
-  }
-  return 0;
+    // Erase is necessary if for any byte:
+    // O & ~N != 0
+    // Where O = original, and N = new byte.
+
+    for(;len>0;len--) {
+        if((~*(flash_addr++) & *(source++)) != 0x00) return 1;
+    }
+    return 0;
 }
 
-// Erase an entire page. pg_addr must be first word of page.
+/**
+  * Erase an entire page
+  * @param page_address address of first word of page
+  */
 void MicroBitFlash::erase_page(uint32_t* pg_addr) {
-  //uBit.serial.printf("erase_page %d 0x%x\n", ((uint32_t)pg_addr / 256), pg_addr);
 
-  // Turn on flash erase enable and wait until the NVMC is ready:
-  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een);
-  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
+    // Turn on flash erase enable and wait until the NVMC is ready:
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een);
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
 
-  // Erase page:
-  NRF_NVMC->ERASEPAGE = (uint32_t)pg_addr;
-  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
+    // Erase page:
+    NRF_NVMC->ERASEPAGE = (uint32_t)pg_addr;
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) { }
 
-  // Turn off flash erase enable and wait until the NVMC is ready:
-  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
-  while (NRF_NVMC->READY == NVMC_READY_READY_Busy);
+    // Turn off flash erase enable and wait until the NVMC is ready:
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy);
 }
  
-// Assumes that this is valid under flash writing rules (see erase_page).
+/**
+  * Write to flash memory, assuming that a write is valid
+  * (using need_erase).
+  *
+  * @param page_address address of memory to write to.
+  *     Must be word aligned.
+  * @param buffer address to write from, must be word-aligned.
+  * @param len number of uint32_t words to write.
+  */
 void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size) {
-  //uBit.serial.printf("flash_burn page %d 0x%x, from 0x%x, size %d\n",
-  //     ((uint32_t)addr / 256), addr, buffer, size);
  
-  // Turn on flash write enable and wait until the NVMC is ready:
-  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
-  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
- 
-  for(int i=0;i<size;i++) {
-    *(addr+i) = *(buffer+i);
+    // Turn on flash write enable and wait until the NVMC is ready:
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
     while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
-  }
  
-  // Turn off flash write enable and wait until the NVMC is ready:
-  NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
-  while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
+    for(int i=0;i<size;i++) {
+        *(addr+i) = *(buffer+i);
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
+    }
+ 
+    // Turn off flash write enable and wait until the NVMC is ready:
+    NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos);
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {};
 }
  
-// Generic function for burning unaligned data, to unaligned flash addresses.
-// Can come from a buffer, or a preset byte value, determined by flash_mode m
+/**
+  * Write to address in flash, implementing either flash_write (copy
+  * data from buffer), or flash_memset (set all bytes in flash to
+  * provided constant.
+  *
+  * Function ensures that data is written correctly:
+  * - erase page if necessary (using need_erase)
+  * - preserve non-target flash by copying to scratch page.
+  *
+  * @param address in flash to write to
+  * @param from_buffer address to write data from
+  * @param write_byte if writing the same byte to add addressed bytes
+  * @param len number of bytes to write to/copy to
+  * @param m mode to use this function, memset/memcpy.
+  * @return non-zero on success, zero on error.
+  */
 int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
-	uint8_t write_byte, int length, flash_mode m) {
+    uint8_t write_byte, int length, flash_mode m) {
 
-  // page number.
-  int page = (address - (uint8_t*)flash_start) / PAGE_SIZE;
+    // page number.
+    int page = (address - (uint8_t*)flash_start) / PAGE_SIZE;
 
-  //page address.
-  uint32_t* pgAddr = flash_start + (page * (PAGE_SIZE/sizeof(uint32_t)));
+    //page address.
+    uint32_t* pgAddr = flash_start + (page * (PAGE_SIZE/sizeof(uint32_t)));
 
-  // offset to write from within page.
-  int offset = (address - (uint8_t*)flash_start) % (int)PAGE_SIZE;
+    // offset to write from within page.
+    int offset = (address - (uint8_t*)flash_start) % (int)PAGE_SIZE;
 
-  // uBit.serial.printf("flash_write to 0x%x, from 0x%x, length: 0x%x\n",
-  //       	     address, from_buffer, length);
-  // uBit.serial.printf(" - offset = %d, pgAddr = 0x%x, page = %d\n",
-  //                    offset, pgAddr, page);
+    // uBit.serial.printf("flash_write to 0x%x, from 0x%x, length: 0x%x\n",
+    //       	     address, from_buffer, length);
+    // uBit.serial.printf(" - offset = %d, pgAddr = 0x%x, page = %d\n",
+    //                    offset, pgAddr, page);
 
-  uint8_t* writeFrom = (uint8_t*)pgAddr;
-  int start = WORD_ADDR(offset);
-  int end = WORD_ADDR((offset+length+4));
+    uint8_t* writeFrom = (uint8_t*)pgAddr;
+    int start = WORD_ADDR(offset);
+    int end = WORD_ADDR((offset+length+4));
 
-  if(need_erase(from_buffer, address, length)) {
-    this->erase_page((uint32_t*)SCRATCH_PAGE_ADDR);
-    this->flash_burn((uint32_t*)SCRATCH_PAGE_ADDR, pgAddr, PAGE_SIZE/4);
-    this->erase_page(pgAddr);
-    writeFrom = (uint8_t*)SCRATCH_PAGE_ADDR;
-    start = 0;
-    end = PAGE_SIZE;
-  }
-
-  uint32_t writeWord = 0;
-
-  for(int i=start;i<end;i++) {
-    int byteOffset = i%4;
-
-    if(i >= offset && i < (offset + length)) {
-      if(m == WR_WRITE) writeWord |= (from_buffer[i-offset] << ((byteOffset)*8));
-      else if(m == WR_MEMSET) writeWord |= ((uint32_t)write_byte << (byteOffset*8));
-    }
-    else {
-      writeWord |= (writeFrom[i] << ((byteOffset)*8));
+    if(need_erase(from_buffer, address, length)) {
+        this->erase_page((uint32_t*)SCRATCH_PAGE_ADDR);
+        this->flash_burn((uint32_t*)SCRATCH_PAGE_ADDR, pgAddr, PAGE_SIZE/4);
+        this->erase_page(pgAddr);
+        writeFrom = (uint8_t*)SCRATCH_PAGE_ADDR;
+        start = 0;
+        end = PAGE_SIZE;
     }
 
-    if( ((i+1)%4) == 0) {
-      this->flash_burn(pgAddr + (i/4), &writeWord, 1);
-      writeWord = 0;
+    uint32_t writeWord = 0;
+
+    for(int i=start;i<end;i++) {
+        int byteOffset = i%4;
+
+        if(i >= offset && i < (offset + length)) {
+            if(m == WR_WRITE) {
+                // Write from buffer.
+                writeWord |= (from_buffer[i-offset] << ((byteOffset)*8));
+            }
+            else if(m == WR_MEMSET) {
+                // Write constant.
+                writeWord |= ((uint32_t)write_byte << (byteOffset*8));
+            }
+        }
+        else {
+            writeWord |= (writeFrom[i] << ((byteOffset)*8));
+        }
+
+        if( ((i+1)%4) == 0) {
+            this->flash_burn(pgAddr + (i/4), &writeWord, 1);
+            writeWord = 0;
+        }
     }
 
-  }
-
-  return 1;
+    return 1;
 }
 
-int MicroBitFlash::flash_write(uint8_t* address, uint8_t* from_buffer, int length) {
- return this->flash_write_mem(address, from_buffer, 0, length, WR_WRITE);
+/**
+  * Writes the given number of bytes to the address in flash specified.
+  * Neither address nor buffer need be word-aligned.
+  * @param address location in flash to write to.
+  * @param buffer location in memory to write from.
+  * @length number of bytes to burn
+  * @return non-zero on sucess, zero on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFlash flash();
+  * uint32_t word = 0x01;
+  * flash.flash_write((uint8_t*)0x38000, &word, sizeof(word))
+  * @endcode
+  */
+int MicroBitFlash::flash_write(uint8_t* address, uint8_t* from_buffer, 
+                               int length) {
+    return this->flash_write_mem(address, from_buffer, 0, length, WR_WRITE);
 }
-int MicroBitFlash::flash_memset(uint8_t* address, uint8_t write_byte, int length) {
- return this->flash_write_mem(address, NULL, write_byte, length, WR_MEMSET);
+
+/**
+  * Set bytes in [address, address+length] to byte.
+  * Neither address nor buffer need be word-aligned.
+  * @param address to write to
+  * @param byte byte to burn to flash
+  * @param length number of bytes to write to.
+  * @return non-zero on success, zero on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFlash flash();
+  * flash.flash_memset((uint8_t*)0x38000, 0x66, 12); //12 bytes to 0x66.
+  * @endcode
+  */
+int MicroBitFlash::flash_memset(uint8_t* address, uint8_t write_byte, 
+                                int length) {
+    return this->flash_write_mem(address, NULL, write_byte, length, WR_MEMSET);
 }
+
+/**
+  * Erase bytes in memory, from set address.
+  * @param address to erase bytes from (needn't be word-aligned.
+  * @param length number of bytes to erase (set to 0xFF).
+  * @return non-zero on success, zero on error.
+  *
+  * Example:
+  * @code
+  * MicroBitFlash flash();
+  * flash.flash_erase((uint8_t*)0x38000, 10240); //erase a flash page.
+  * @endcode
+  */
 int MicroBitFlash::flash_erase_mem(uint8_t* address, int length) {
- return this->flash_write_mem(address, NULL, 0xFF, length, WR_MEMSET);
+    return this->flash_write_mem(address, NULL, 0xFF, length, WR_MEMSET);
 }
 

--- a/source/MicroBitFlash.cpp
+++ b/source/MicroBitFlash.cpp
@@ -8,8 +8,8 @@
 /**
   * Default Constructor
   */
-MicroBitFlash::MicroBitFlash() {
-  this->flash_start = (uint32_t*)FLASH_START;
+MicroBitFlash::MicroBitFlash() 
+{
 }
 
 /**
@@ -23,7 +23,8 @@ MicroBitFlash::MicroBitFlash() {
   * @param len number of uint8_t to check.
   * @return non-zero if erase required, zero otherwise.
   */
-int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len) {
+int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len) 
+{
     // Erase is necessary if for any byte:
     // O & ~N != 0
     // Where O = original, and N = new byte.
@@ -38,7 +39,8 @@ int MicroBitFlash::need_erase(uint8_t* source, uint8_t* flash_addr, int len) {
   * Erase an entire page
   * @param page_address address of first word of page
   */
-void MicroBitFlash::erase_page(uint32_t* pg_addr) {
+void MicroBitFlash::erase_page(uint32_t* pg_addr) 
+{
 
     // Turn on flash erase enable and wait until the NVMC is ready:
     NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Een);
@@ -62,7 +64,8 @@ void MicroBitFlash::erase_page(uint32_t* pg_addr) {
   * @param buffer address to write from, must be word-aligned.
   * @param len number of uint32_t words to write.
   */
-void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size) {
+void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size) 
+{
  
     // Turn on flash write enable and wait until the NVMC is ready:
     NRF_NVMC->CONFIG = (NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos);
@@ -95,16 +98,17 @@ void MicroBitFlash::flash_burn(uint32_t* addr, uint32_t* buffer, int size) {
   * @return non-zero on success, zero on error.
   */
 int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
-    uint8_t write_byte, int length, flash_mode m) {
+    uint8_t write_byte, int length, flash_mode m) 
+{
 
     // page number.
-    int page = (address - (uint8_t*)flash_start) / PAGE_SIZE;
+    int page = (uint32_t)address / PAGE_SIZE;
 
     //page address.
-    uint32_t* pgAddr = flash_start + (page * (PAGE_SIZE/sizeof(uint32_t)));
+    uint32_t* pgAddr = (uint32_t*)(page * PAGE_SIZE);
 
     // offset to write from within page.
-    int offset = (address - (uint8_t*)flash_start) % (int)PAGE_SIZE;
+    int offset = (uint32_t)address % PAGE_SIZE;
 
     // uBit.serial.printf("flash_write to 0x%x, from 0x%x, length: 0x%x\n",
     //       	     address, from_buffer, length);
@@ -168,7 +172,8 @@ int MicroBitFlash::flash_write_mem(uint8_t* address, uint8_t* from_buffer,
   * @endcode
   */
 int MicroBitFlash::flash_write(uint8_t* address, uint8_t* from_buffer, 
-                               int length) {
+                               int length) 
+{
     return this->flash_write_mem(address, from_buffer, 0, length, WR_WRITE);
 }
 
@@ -187,7 +192,8 @@ int MicroBitFlash::flash_write(uint8_t* address, uint8_t* from_buffer,
   * @endcode
   */
 int MicroBitFlash::flash_memset(uint8_t* address, uint8_t write_byte, 
-                                int length) {
+                                int length) 
+{
     return this->flash_write_mem(address, NULL, write_byte, length, WR_MEMSET);
 }
 
@@ -203,7 +209,8 @@ int MicroBitFlash::flash_memset(uint8_t* address, uint8_t write_byte,
   * flash.flash_erase((uint8_t*)0x38000, 10240); //erase a flash page.
   * @endcode
   */
-int MicroBitFlash::flash_erase_mem(uint8_t* address, int length) {
+int MicroBitFlash::flash_erase_mem(uint8_t* address, int length) 
+{
     return this->flash_write_mem(address, NULL, 0xFF, length, WR_MEMSET);
 }
 


### PR DESCRIPTION
Basic filesystem API for the MicroBit.
Total code size is 1.8KB
Total RAM size is 72B - although there is room to reduce this
POSIX-ish interface: open/close/read/write/seek/unlink. All calls are synchronous.

Design of the file system is quite well-documented in MicroBitFile.h, configuration options in MicroBitFile_config.h

MicroBitFlash.h/cpp is used for read/write to flash. This has some crossover with MicroBitStorage.

Code still needs some further work (including points listed below), but this should be quite close to the final thing.

@todo agree on flash location and pages allocated for the filesystem.
@todo add MB_APPEND flag in open().
@todo Interrupt-safety in MicroBitFlash.
@todo Include MicroBitFile instance into uBit object.

The KL26z USB interface code will (shortly) be able to read the filesystem from the Nordic chip over SWD, present it as a html/js file when the MicroBit is plugged in, where it can be parsed, and read in a web browser. Code for this is basically finished, will be make a pull request to the DAPLink repo soon.

Happy to hear comments/feedback, hope you all have a good Easter :-)