### PR TITLE
Fix MICROBIT_IO_PIN_SERVICE_PINCOUNT

### DIFF
--- a/inc/bluetooth/MicroBitIOPinService.h
+++ b/inc/bluetooth/MicroBitIOPinService.h
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.
 #include "ble/BLE.h"
 #include "MicroBitIO.h"
 
-#define MICROBIT_IO_PIN_SERVICE_PINCOUNT       20
+#define MICROBIT_IO_PIN_SERVICE_PINCOUNT       19
 #define MICROBIT_IO_PIN_SERVICE_DATA_SIZE      10
 
 // UUIDs for our service and characteristics


### PR DESCRIPTION
MicroBitIO only has 19 pins.