### PR TITLE
Add missing const qualifier from add operator

### DIFF
--- a/inc/types/ManagedString.h
+++ b/inc/types/ManagedString.h
@@ -314,7 +314,7 @@ class ManagedString
       * display.scroll(s + p) // scrolls "abcdefgh"
       * @endcode
       */
-    ManagedString operator+ (ManagedString& s);
+    ManagedString operator+ (const ManagedString& s);
 
     /**
       * Provides a character value at a given position in the string, indexed from zero.

--- a/source/types/ManagedString.cpp
+++ b/source/types/ManagedString.cpp
@@ -451,7 +451,7 @@ ManagedString ManagedString::substring(int16_t start, int16_t length)
   * display.scroll(s + p) // scrolls "abcdefgh"
   * @endcode
   */
-ManagedString ManagedString::operator+ (ManagedString& s)
+ManagedString ManagedString::operator+ (const ManagedString& s)
 {
     // If the other string is empty, nothing to do!
     if(s.length() == 0)


### PR DESCRIPTION
This change permits friendlier use of the type such as:

```C++
ManagedString s = "A";
ManagedString b = s + ", " + 2;
```