### PR TITLE
Make sure there is only one empty string

### DIFF
--- a/source/types/ManagedString.cpp
+++ b/source/types/ManagedString.cpp
@@ -210,6 +210,11 @@ ManagedString::ManagedString(const ManagedString &s1, const ManagedString &s2)
   */
 ManagedString::ManagedString(PacketBuffer buffer)
 {
+    if (buffer.length() == 0) {
+        initEmpty();
+        return;
+    }
+
     // Allocate a new buffer ( just in case the data is not NULL terminated).
     ptr = (StringData*) malloc(4+buffer.length()+1);
     ptr->init();
@@ -238,7 +243,7 @@ ManagedString::ManagedString(PacketBuffer buffer)
 ManagedString::ManagedString(const char *str, const int16_t length)
 {
     // Sanity check. Return EmptyString for anything distasteful
-    if (str == NULL || *str == 0 || (uint16_t)length > strlen(str)) // XXX length should be unsigned on the interface
+    if (str == NULL || *str == 0 || length == 0 || (uint16_t)length > strlen(str)) // XXX length should be unsigned on the interface
     {
         initEmpty();
         return;


### PR DESCRIPTION
This makes sure we always re-use a single empty string instance. We were not doing that in some extreme circumstances