### PR TITLE
Update dependencies for older gcc compilation for MicroPython.

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
   "name": "microbit-dal",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "license": "MIT",
   "description": "The runtime library for the BBC micro:bit, developed by Lancaster University",
   "keywords": [
@@ -16,8 +16,8 @@
   "dependencies": {
     "mbed-classic": "lancaster-university/mbed-classic#microbit_hfclk",
     "ble": "lancaster-university/BLE_API#v2.5.0+mb3",
-    "ble-nrf51822": "lancaster-university/nrf51822#v2.5.0+mb5",
-    "nrf51-sdk": "lancaster-university/nrf51-sdk#v2.2.0+mb3"
+    "ble-nrf51822": "lancaster-university/nrf51822#v2.5.0+mb6",
+    "nrf51-sdk": "lancaster-university/nrf51-sdk#v2.2.0+mb4"
   },
   "extraIncludes": [
     "inc"


### PR DESCRIPTION
Basically we need to update the nRF51822 version to `nrf51822#v2.5.0+mb6` containing this commit https://github.com/lancaster-university/nRF51822/commit/c5ce428daede8d939c4496453e84d03955c99804 to resolve https://github.com/bbcmicrobit/micropython/issues/338 (more info on https://github.com/ARMmbed/ble-nrf51822/issues/133).

This PR is targetting `www-microbit-co-uk`, but ideally I'd suggest to create a new branch from tag `v1.4.19` and and then change this PR base branch to it (GitHub has added that [feature](https://github.com/blog/2224-change-the-base-branch-of-a-pull-request) not that long ago). Or do this manually, whichever you prefer. 