### PR TITLE
microbit-dal: Minimalist Keyboard HID Service

### DIFF
--- a/inc/bluetooth/MicroBitDeviceInformationService.h
+++ b/inc/bluetooth/MicroBitDeviceInformationService.h
@@ -1,0 +1,145 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BLE_HID_DEVICE_INFORMATION_SERVICE_H__
+#define __BLE_HID_DEVICE_INFORMATION_SERVICE_H__
+
+#include "ble/BLE.h"
+
+typedef struct
+{
+    uint8_t vendorID_source;
+    uint16_t vendorID;
+    uint16_t productID;
+    uint16_t productVersion;
+} PnPID_t;
+
+/**
+* @class HIDDeviceInformationService
+* @brief BLE Device Information Service <br>
+* Service: https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.device_information.xml <br>
+* Manufacturer Name String Char: https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.manufacturer_name_string.xml
+*/
+class HIDDeviceInformationService {
+public:
+    /**
+     * @brief Device Information Service Constructor.
+     *
+     * @param[ref] _ble
+     *                BLE object for the underlying controller.
+     * @param[in] manufacturersName
+     *                This characteristic represents the name of the
+     *                manufacturer of the device. The name is copied into the
+     *                BLE stack during this constructor.
+     * @param[in] modelNumber
+     *                This characteristic represents the model number that is
+     *                assigned by the device vendor. The value is copied into
+     *                the BLE stack during this constructor.
+     * @param[in] serialNumber
+     *                This characteristic represents the serial number for a
+     *                particular instance of the device.  The value is copied
+     *                into the BLE stack during this constructor.
+     * @param[in] hardwareRevision
+     *                This characteristic represents the hardware revision for
+     *                the hardware within the device. The value is copied
+     *                into the BLE stack during this constructor.
+     * @param[in] firmwareRevision
+     *                This characteristic represents the firmware revision for
+     *                the firmware within the device. The value is copied
+     *                into the BLE stack during this constructor.
+     * @param[in] softwareRevision
+     *                This characteristic represents the software revision for
+     *                the software within the device. The value is copied
+     *                into the BLE stack during this constructor.
+     * @param[in] pnpID
+     *                This characteristic represents HID-specific information,
+     *                such as vendor id, product id and version.
+     */
+    HIDDeviceInformationService(BLE            &_ble,
+                             const char     *manufacturersName = NULL,
+                             const char     *modelNumber       = NULL,
+                             const char     *serialNumber      = NULL,
+                             const char     *hardwareRevision  = NULL,
+                             const char     *firmwareRevision  = NULL,
+                             const char     *softwareRevision  = NULL,
+                             PnPID_t        *PnPID             = NULL) :
+        ble(_ble)
+    {
+        static bool serviceAdded = false; /* We should only ever need to add the information service once. */
+        if (serviceAdded) {
+            return;
+        }
+
+        GattCharacteristic manufacturersNameStringCharacteristic(GattCharacteristic::UUID_MANUFACTURER_NAME_STRING_CHAR,
+                                              (uint8_t *)manufacturersName,
+                                              (manufacturersName != NULL) ? strlen(manufacturersName) : 0, /* minLength */
+                                              (manufacturersName != NULL) ? strlen(manufacturersName) : 0, /* maxLength */
+                                              GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic modelNumberStringCharacteristic(GattCharacteristic::UUID_MODEL_NUMBER_STRING_CHAR,
+                                        (uint8_t *)modelNumber,
+                                        (modelNumber != NULL) ? strlen(modelNumber) : 0, /* minLength */
+                                        (modelNumber != NULL) ? strlen(modelNumber) : 0, /* maxLength */
+                                        GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic serialNumberStringCharacteristic(GattCharacteristic::UUID_SERIAL_NUMBER_STRING_CHAR,
+                                         (uint8_t *)serialNumber,
+                                         (serialNumber != NULL) ? strlen(serialNumber) : 0, /* minLength */
+                                         (serialNumber != NULL) ? strlen(serialNumber) : 0, /* maxLength */
+                                         GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic hardwareRevisionStringCharacteristic(GattCharacteristic::UUID_HARDWARE_REVISION_STRING_CHAR,
+                                             (uint8_t *)hardwareRevision,
+                                             (hardwareRevision != NULL) ? strlen(hardwareRevision) : 0, /* minLength */
+                                             (hardwareRevision != NULL) ? strlen(hardwareRevision) : 0, /* maxLength */
+                                             GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic firmwareRevisionStringCharacteristic(GattCharacteristic::UUID_FIRMWARE_REVISION_STRING_CHAR,
+                                             (uint8_t *)firmwareRevision,
+                                             (firmwareRevision != NULL) ? strlen(firmwareRevision) : 0, /* minLength */
+                                             (firmwareRevision != NULL) ? strlen(firmwareRevision) : 0, /* maxLength */
+                                             GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic softwareRevisionStringCharacteristic(GattCharacteristic::UUID_SOFTWARE_REVISION_STRING_CHAR,
+                                             (uint8_t *)softwareRevision,
+                                             (softwareRevision != NULL) ? strlen(softwareRevision) : 0, /* minLength */
+                                             (softwareRevision != NULL) ? strlen(softwareRevision) : 0, /* maxLength */
+                                             GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+
+        GattCharacteristic pnpIDCharacteristic(GattCharacteristic::UUID_PNP_ID_CHAR, (uint8_t *)PnPID);
+
+        GattCharacteristic *charTable[] = {&manufacturersNameStringCharacteristic,
+                                           &modelNumberStringCharacteristic,
+                                           &serialNumberStringCharacteristic,
+                                           &hardwareRevisionStringCharacteristic,
+                                           &firmwareRevisionStringCharacteristic,
+                                           &softwareRevisionStringCharacteristic,
+                                           &pnpIDCharacteristic};
+
+        GattService         deviceInformationService(GattService::UUID_DEVICE_INFORMATION_SERVICE, charTable,
+                                                     sizeof(charTable) / sizeof(GattCharacteristic *));
+
+        // for some reason, this causes the micro:bit build to break.
+        // pnpIDCharacteristic.requireSecurity(SecurityManager::SECURITY_MODE_ENCRYPTION_NO_MITM);
+        ble.addService(deviceInformationService);
+        serviceAdded = true;
+    }
+
+protected:
+    BLE                 &ble;
+};
+
+#endif /* #ifndef __BLE_HID_DEVICE_INFORMATION_SERVICE_H__*/

--- a/inc/bluetooth/MicrobitKeyboardService.h
+++ b/inc/bluetooth/MicrobitKeyboardService.h
@@ -1,0 +1,99 @@
+#ifndef MICROBIT_KEYBOARD_SERVICE_H
+#define MICROBIT_KEYBOARD_SERVICE_H
+
+#include "hid/BluetoothHIDTypes.h"
+#include "hid/BluetoothHIDKeys.h"
+#include "ble/services/BatteryService.h"
+#include "ManagedString.h"
+#include "ble/BLE.h"
+
+#include "MicroBitComponent.h"
+
+#define MICROBIT_HID_S_EVT_TX_EMPTY     1
+#define MICROBIT_HID_ADVERTISING_INT    24
+
+/**
+  * This class represents a Bluetooth HID device, specifically, a keyboard instance.
+  *
+  * A few things to note:
+  *     - HID devices require a battery service (automatically instantiated with this class)
+  *     - Security is required, this class has only been tested using Just Works pairing.
+  *     - On mac to get it to pair, you may have to interrogate a secure characteristic of the micro:bit via LightBlue
+  *       in order to initiate pairing.
+  *     - It is designed to be as light weight as possible, and employs tactics like the stack allocation of
+  *       gatt characteristics to alleviate RAM pressures.
+  */
+class MicroBitKeyboardService : public MicroBitComponent
+{
+    private:
+    BLEDevice& ble;
+    BatteryService* batteryService;
+
+    GattCharacteristic* keyboardInCharacteristic;
+
+    /**
+      * A simple helper function that "returns" our most recently "pressed" key to
+      * the up position.
+      */
+    void keyUp();
+
+    public:
+
+    /**
+      * Constructor for our keyboard service.
+      *
+      * Creates a collection of characteristics, instantiates a battery service,
+      * and modifies advertisement data.
+      */
+    MicroBitKeyboardService(BLEDevice& _ble);
+
+    /**
+      * System tick is used to time the visibility of characters from the HID device.
+      *
+      * Our HID advertising interval is 24 ms, which means there will be a character
+      * swap every 24 ms. Our system tick timer interrupt occures every 6ms...
+      *
+      * After we swap characters, we reset our counter, and emit an event to wake any
+      * waiting fibers.
+      */
+    virtual void systemTick();
+
+    /**
+      * Send a single character to our host.
+      *
+      * @param c the character to send
+      *
+      * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+      */
+    int send(const char c);
+
+    /**
+      * Send a buffer of characters to our host.
+      *
+      * @param data the characters to send
+      *
+      * @param len the number of characters in the buffer.
+      *
+      * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+      */
+    int send(const char* data, int len);
+
+    /**
+      * Send a ManagedString to our host.
+      *
+      * @param data the string to send
+      *
+      * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+      */
+    int send(ManagedString data);
+
+    /**
+      * Destructor.
+      *
+      * Frees our heap allocated characteristic and service, and remove this instance
+      * from our system timer interrupt.
+      */
+    ~MicroBitKeyboardService();
+};
+
+#endif

--- a/inc/bluetooth/hid/BluetoothHIDKeys.h
+++ b/inc/bluetooth/hid/BluetoothHIDKeys.h
@@ -1,0 +1,239 @@
+/* Copyright (c) 2015 mbed.org, MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Note: this file was pulled from different parts of the USBHID library, in mbed SDK
+ */
+
+#ifndef KEYBOARD_DEFS_H
+#define KEYBOARD_DEFS_H
+
+#define REPORT_ID_KEYBOARD 1
+#define REPORT_ID_VOLUME   3
+
+/* Modifiers */
+enum InputModifier {
+    KEY_NONE = 0,
+    KEY_CTRL = 1,
+    KEY_SHIFT = 2,
+    KEY_ALT = 4,
+};
+
+enum MediaKey {
+    KEY_NEXT_TRACK,     /*!< next Track Button */
+    KEY_PREVIOUS_TRACK, /*!< Previous track Button */
+    KEY_STOP,           /*!< Stop Button */
+    KEY_PLAY_PAUSE,     /*!< Play/Pause Button */
+    KEY_MUTE,           /*!< Mute Button */
+    KEY_VOLUME_UP,      /*!< Volume Up Button */
+    KEY_VOLUME_DOWN,    /*!< Volume Down Button */
+};
+
+enum FunctionKey {
+    KEY_F1 = 128,   /* F1 key */
+    KEY_F2,         /* F2 key */
+    KEY_F3,         /* F3 key */
+    KEY_F4,         /* F4 key */
+    KEY_F5,         /* F5 key */
+    KEY_F6,         /* F6 key */
+    KEY_F7,         /* F7 key */
+    KEY_F8,         /* F8 key */
+    KEY_F9,         /* F9 key */
+    KEY_F10,        /* F10 key */
+    KEY_F11,        /* F11 key */
+    KEY_F12,        /* F12 key */
+
+    KEY_PRINT_SCREEN,   /* Print Screen key */
+    KEY_SCROLL_LOCK,    /* Scroll lock */
+    KEY_CAPS_LOCK,      /* caps lock */
+    KEY_NUM_LOCK,       /* num lock */
+    KEY_INSERT,         /* Insert key */
+    KEY_HOME,           /* Home key */
+    KEY_PAGE_UP,        /* Page Up key */
+    KEY_PAGE_DOWN,      /* Page Down key */
+
+    RIGHT_ARROW,        /* Right arrow */
+    LEFT_ARROW,         /* Left arrow */
+    DOWN_ARROW,         /* Down arrow */
+    UP_ARROW,           /* Up arrow */
+};
+
+typedef struct {
+    unsigned char usage;
+    unsigned char modifier;
+} KEYMAP;
+
+/* UK keyboard */
+#define KEYMAP_SIZE (152)
+const KEYMAP keymap[KEYMAP_SIZE] = {
+    {0, 0},             /* NUL */
+    {0, 0},             /* SOH */
+    {0, 0},             /* STX */
+    {0, 0},             /* ETX */
+    {0, 0},             /* EOT */
+    {0, 0},             /* ENQ */
+    {0, 0},             /* ACK */
+    {0, 0},             /* BEL */
+    {0x2a, 0},          /* BS  */  /* Keyboard Delete (Backspace) */
+    {0x2b, 0},          /* TAB */  /* Keyboard Tab */
+    {0x28, 0},          /* LF  */  /* Keyboard Return (Enter) */
+    {0, 0},             /* VT  */
+    {0, 0},             /* FF  */
+    {0, 0},             /* CR  */
+    {0, 0},             /* SO  */
+    {0, 0},             /* SI  */
+    {0, 0},             /* DEL */
+    {0, 0},             /* DC1 */
+    {0, 0},             /* DC2 */
+    {0, 0},             /* DC3 */
+    {0, 0},             /* DC4 */
+    {0, 0},             /* NAK */
+    {0, 0},             /* SYN */
+    {0, 0},             /* ETB */
+    {0, 0},             /* CAN */
+    {0, 0},             /* EM  */
+    {0, 0},             /* SUB */
+    {0, 0},             /* ESC */
+    {0, 0},             /* FS  */
+    {0, 0},             /* GS  */
+    {0, 0},             /* RS  */
+    {0, 0},             /* US  */
+    {0x2c, 0},          /*   */
+    {0x1e, KEY_SHIFT},      /* ! */
+    {0x1f, KEY_SHIFT},      /* " */
+    {0x32, 0},          /* # */
+    {0x21, KEY_SHIFT},      /* $ */
+    {0x22, KEY_SHIFT},      /* % */
+    {0x24, KEY_SHIFT},      /* & */
+    {0x34, 0},          /* ' */
+    {0x26, KEY_SHIFT},      /* ( */
+    {0x27, KEY_SHIFT},      /* ) */
+    {0x25, KEY_SHIFT},      /* * */
+    {0x2e, KEY_SHIFT},      /* + */
+    {0x36, 0},          /* , */
+    {0x2d, 0},          /* - */
+    {0x37, 0},          /* . */
+    {0x38, 0},          /* / */
+    {0x27, 0},          /* 0 */
+    {0x1e, 0},          /* 1 */
+    {0x1f, 0},          /* 2 */
+    {0x20, 0},          /* 3 */
+    {0x21, 0},          /* 4 */
+    {0x22, 0},          /* 5 */
+    {0x23, 0},          /* 6 */
+    {0x24, 0},          /* 7 */
+    {0x25, 0},          /* 8 */
+    {0x26, 0},          /* 9 */
+    {0x33, KEY_SHIFT},      /* : */
+    {0x33, 0},          /* ; */
+    {0x36, KEY_SHIFT},      /* < */
+    {0x2e, 0},          /* = */
+    {0x37, KEY_SHIFT},      /* > */
+    {0x38, KEY_SHIFT},      /* ? */
+    {0x34, KEY_SHIFT},      /* @ */
+    {0x04, KEY_SHIFT},      /* A */
+    {0x05, KEY_SHIFT},      /* B */
+    {0x06, KEY_SHIFT},      /* C */
+    {0x07, KEY_SHIFT},      /* D */
+    {0x08, KEY_SHIFT},      /* E */
+    {0x09, KEY_SHIFT},      /* F */
+    {0x0a, KEY_SHIFT},      /* G */
+    {0x0b, KEY_SHIFT},      /* H */
+    {0x0c, KEY_SHIFT},      /* I */
+    {0x0d, KEY_SHIFT},      /* J */
+    {0x0e, KEY_SHIFT},      /* K */
+    {0x0f, KEY_SHIFT},      /* L */
+    {0x10, KEY_SHIFT},      /* M */
+    {0x11, KEY_SHIFT},      /* N */
+    {0x12, KEY_SHIFT},      /* O */
+    {0x13, KEY_SHIFT},      /* P */
+    {0x14, KEY_SHIFT},      /* Q */
+    {0x15, KEY_SHIFT},      /* R */
+    {0x16, KEY_SHIFT},      /* S */
+    {0x17, KEY_SHIFT},      /* T */
+    {0x18, KEY_SHIFT},      /* U */
+    {0x19, KEY_SHIFT},      /* V */
+    {0x1a, KEY_SHIFT},      /* W */
+    {0x1b, KEY_SHIFT},      /* X */
+    {0x1c, KEY_SHIFT},      /* Y */
+    {0x1d, KEY_SHIFT},      /* Z */
+    {0x2f, 0},          /* [ */
+    {0x64, 0},          /* \ */
+    {0x30, 0},          /* ] */
+    {0x23, KEY_SHIFT},      /* ^ */
+    {0x2d, KEY_SHIFT},      /* _ */
+    {0x35, 0},          /* ` */
+    {0x04, 0},          /* a */
+    {0x05, 0},          /* b */
+    {0x06, 0},          /* c */
+    {0x07, 0},          /* d */
+    {0x08, 0},          /* e */
+    {0x09, 0},          /* f */
+    {0x0a, 0},          /* g */
+    {0x0b, 0},          /* h */
+    {0x0c, 0},          /* i */
+    {0x0d, 0},          /* j */
+    {0x0e, 0},          /* k */
+    {0x0f, 0},          /* l */
+    {0x10, 0},          /* m */
+    {0x11, 0},          /* n */
+    {0x12, 0},          /* o */
+    {0x13, 0},          /* p */
+    {0x14, 0},          /* q */
+    {0x15, 0},          /* r */
+    {0x16, 0},          /* s */
+    {0x17, 0},          /* t */
+    {0x18, 0},          /* u */
+    {0x19, 0},          /* v */
+    {0x1a, 0},          /* w */
+    {0x1b, 0},          /* x */
+    {0x1c, 0},          /* y */
+    {0x1d, 0},          /* z */
+    {0x2f, KEY_SHIFT},      /* { */
+    {0x64, KEY_SHIFT},      /* | */
+    {0x30, KEY_SHIFT},      /* } */
+    {0x32, KEY_SHIFT},      /* ~ */
+    {0,0},             /* DEL */
+
+    {0x3a, 0},          /* F1 */
+    {0x3b, 0},          /* F2 */
+    {0x3c, 0},          /* F3 */
+    {0x3d, 0},          /* F4 */
+    {0x3e, 0},          /* F5 */
+    {0x3f, 0},          /* F6 */
+    {0x40, 0},          /* F7 */
+    {0x41, 0},          /* F8 */
+    {0x42, 0},          /* F9 */
+    {0x43, 0},          /* F10 */
+    {0x44, 0},          /* F11 */
+    {0x45, 0},          /* F12 */
+
+    {0x46, 0},          /* PRINT_SCREEN */
+    {0x47, 0},          /* SCROLL_LOCK */
+    {0x39, 0},          /* CAPS_LOCK */
+    {0x53, 0},          /* NUM_LOCK */
+    {0x49, 0},          /* INSERT */
+    {0x4a, 0},          /* HOME */
+    {0x4b, 0},          /* PAGE_UP */
+    {0x4e, 0},          /* PAGE_DOWN */
+
+    {0x4f, 0},          /* RIGHT_ARROW */
+    {0x50, 0},          /* LEFT_ARROW */
+    {0x51, 0},          /* DOWN_ARROW */
+    {0x52, 0},          /* UP_ARROW */
+};
+
+#endif

--- a/inc/bluetooth/hid/BluetoothHIDTypes.h
+++ b/inc/bluetooth/hid/BluetoothHIDTypes.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2010-2011 mbed.org, MIT License
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+* and associated documentation files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all copies or
+* substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+* BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+* DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef USBCLASS_HID_TYPES
+#define USBCLASS_HID_TYPES
+
+#include <stdint.h>
+
+/* */
+#define HID_VERSION_1_11    (0x0111)
+
+/* HID Class */
+#define HID_CLASS           (3)
+#define HID_SUBCLASS_NONE   (0)
+#define HID_PROTOCOL_NONE   (0)
+
+/* Descriptors */
+#define HID_DESCRIPTOR          (33)
+#define HID_DESCRIPTOR_LENGTH   (0x09)
+#define REPORT_DESCRIPTOR       (34)
+
+/* Class requests */
+#define GET_REPORT (0x1)
+#define GET_IDLE   (0x2)
+#define SET_REPORT (0x9)
+#define SET_IDLE   (0xa)
+
+/* HID Class Report Descriptor */
+/* Short items: size is 0, 1, 2 or 3 specifying 0, 1, 2 or 4 (four) bytes */
+/* of data as per HID Class standard */
+
+/* Main items */
+#define INPUT(size)             (0x80 | size)
+#define OUTPUT(size)            (0x90 | size)
+#define FEATURE(size)           (0xb0 | size)
+#define COLLECTION(size)        (0xa0 | size)
+#define END_COLLECTION(size)    (0xc0 | size)
+
+/* Global items */
+#define USAGE_PAGE(size)        (0x04 | size)
+#define LOGICAL_MINIMUM(size)   (0x14 | size)
+#define LOGICAL_MAXIMUM(size)   (0x24 | size)
+#define PHYSICAL_MINIMUM(size)  (0x34 | size)
+#define PHYSICAL_MAXIMUM(size)  (0x44 | size)
+#define UNIT_EXPONENT(size)     (0x54 | size)
+#define UNIT(size)              (0x64 | size)
+#define REPORT_SIZE(size)       (0x74 | size)
+#define REPORT_ID(size)         (0x84 | size)
+#define REPORT_COUNT(size)      (0x94 | size)
+#define PUSH(size)              (0xa4 | size)
+#define POP(size)               (0xb4 | size)
+
+/* Local items */
+#define USAGE(size)                 (0x08 | size)
+#define USAGE_MINIMUM(size)         (0x18 | size)
+#define USAGE_MAXIMUM(size)         (0x28 | size)
+#define DESIGNATOR_INDEX(size)      (0x38 | size)
+#define DESIGNATOR_MINIMUM(size)    (0x48 | size)
+#define DESIGNATOR_MAXIMUM(size)    (0x58 | size)
+#define STRING_INDEX(size)          (0x78 | size)
+#define STRING_MINIMUM(size)        (0x88 | size)
+#define STRING_MAXIMUM(size)        (0x98 | size)
+#define DELIMITER(size)             (0xa8 | size)
+
+/* HID Report */
+/* Where report IDs are used the first byte of 'data' will be the */
+/* report ID and 'length' will include this report ID byte. */
+
+#define MAX_HID_REPORT_SIZE (64)
+
+typedef struct {
+    uint32_t length;
+    uint8_t data[MAX_HID_REPORT_SIZE];
+} HID_REPORT;
+
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -52,6 +52,7 @@ set(YOTTA_AUTO_MICROBIT-DAL_CPP_FILES
     "bluetooth/MicroBitEddystone.cpp"
     "bluetooth/MicroBitEventService.cpp"
     "bluetooth/MicroBitIOPinService.cpp"
+    "bluetooth/MicroBitKeyboardService.cpp"
     "bluetooth/MicroBitLEDService.cpp"
     "bluetooth/MicroBitMagnetometerService.cpp"
     "bluetooth/MicroBitTemperatureService.cpp"

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitEddystone.h"
 #include "MicroBitStorage.h"
 #include "MicroBitFiber.h"
+#include "MicroBitDeviceInformationService.h"
 
 /* The underlying Nordic libraries that support BLE do not compile cleanly with the stringent GCC settings we employ.
  * If we're compiling under GCC, then we suppress any warnings generated from this code (but not the rest of the DAL)
@@ -87,6 +88,10 @@ MicroBitBLEManager *MicroBitBLEManager::manager = NULL; // Singleton reference t
 
 static uint8_t deviceID = 255;          // Unique ID for the peer that has connected to us.
 static Gap::Handle_t pairingHandle = 0; // The connection handle used during a pairing process. Used to ensure that connections are dropped elegantly.
+
+static const PnPID_t pnp = {
+    0x2, 0x0d28, 0x204, 0x0100
+};
 
 static void storeSystemAttributes(Gap::Handle_t handle)
 {
@@ -280,6 +285,8 @@ void MicroBitBLEManager::advertise()
   * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true);
   * @endcode
   */
+
+static const uint16_t uuid16_list[] = {GattService::UUID_HUMAN_INTERFACE_DEVICE_SERVICE};
 void MicroBitBLEManager::init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, bool enableBonding)
 {
     ManagedString BLEName("BBC micro:bit");
@@ -372,7 +379,7 @@ void MicroBitBLEManager::init(ManagedString deviceName, ManagedString serialNumb
 #endif
 
 #if CONFIG_ENABLED(MICROBIT_BLE_DEVICE_INFORMATION_SERVICE)
-    DeviceInformationService ble_device_information_service(*ble, MICROBIT_BLE_MANUFACTURER, MICROBIT_BLE_MODEL, serialNumber.toCharArray(), MICROBIT_BLE_HARDWARE_VERSION, MICROBIT_BLE_FIRMWARE_VERSION, MICROBIT_BLE_SOFTWARE_VERSION);
+    HIDDeviceInformationService ble_device_information_service(*ble, MICROBIT_BLE_MANUFACTURER, MICROBIT_BLE_MODEL, serialNumber.toCharArray(), MICROBIT_BLE_HARDWARE_VERSION, MICROBIT_BLE_FIRMWARE_VERSION, MICROBIT_BLE_SOFTWARE_VERSION, (PnPID_t *)&pnp);
 #else
     (void)serialNumber;
 #endif

--- a/source/bluetooth/MicroBitKeyboardService.cpp
+++ b/source/bluetooth/MicroBitKeyboardService.cpp
@@ -1,0 +1,254 @@
+#include "MicroBitKeyboardService.h"
+#include "ble/UUID.h"
+#include "ble/GattCharacteristic.h"
+#include "MicroBitEvent.h"
+#include "MicroBitFiber.h"
+#include "MicroBitSystemTimer.h"
+
+struct HIDReportReference{
+    uint8_t id;
+    uint8_t type;
+};
+
+struct HIDInformation{
+    uint16_t bcdHID;
+    uint8_t  bCountryCode;
+    uint8_t  flags;
+};
+
+#define BLE_UUID_DESCRIPTOR_REPORT_REFERENCE 0x2908
+
+#define HID_INPUT_REPORT        0x01
+#define HID_OUTPUT_REPORT       0x02
+#define HID_FEATURE_REPORT      0x03
+
+#define HID_REPORT_COUNT        3
+
+const HIDReportReference reports[HID_REPORT_COUNT] = {
+    {
+        0,
+        HID_INPUT_REPORT
+    },
+    {
+        1,
+        HID_OUTPUT_REPORT
+    },
+    {
+        2,
+        HID_FEATURE_REPORT
+    },
+};
+
+const uint8_t reportMap[] = {
+    USAGE_PAGE(1),      0x01,       // Generic Desktop Ctrls
+    USAGE(1),           0x06,       // Keyboard
+    COLLECTION(1),      0x01,       // Application
+    USAGE_PAGE(1),      0x07,       //   Kbrd/Keypad
+    USAGE_MINIMUM(1),   0xE0,
+    USAGE_MAXIMUM(1),   0xE7,
+    LOGICAL_MINIMUM(1), 0x00,
+    LOGICAL_MAXIMUM(1), 0x01,
+    REPORT_SIZE(1),     0x01,       //   1 byte (Modifier)
+    REPORT_COUNT(1),    0x08,
+    INPUT(1),           0x02,       //   Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position
+    REPORT_COUNT(1),    0x01,       //   1 byte (Reserved)
+    REPORT_SIZE(1),     0x08,
+    INPUT(1),           0x01,       //   Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position
+    REPORT_COUNT(1),    0x05,       //   5 bits (Num lock, Caps lock, Scroll lock, Compose, Kana)
+    REPORT_SIZE(1),     0x01,
+    USAGE_PAGE(1),      0x08,       //   LEDs
+    USAGE_MINIMUM(1),   0x01,       //   Num Lock
+    USAGE_MAXIMUM(1),   0x05,       //   Kana
+    OUTPUT(1),          0x02,       //   Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile
+    REPORT_COUNT(1),    0x01,       //   3 bits (Padding)
+    REPORT_SIZE(1),     0x03,
+    OUTPUT(1),          0x01,       //   Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile
+    REPORT_COUNT(1),    0x06,       //   6 bytes (Keys)
+    REPORT_SIZE(1),     0x08,
+    LOGICAL_MINIMUM(1), 0x00,
+    LOGICAL_MAXIMUM(1), 0x65,       //   101 keys
+    USAGE_PAGE(1),      0x07,       //   Kbrd/Keypad
+    USAGE_MINIMUM(1),   0x00,
+    USAGE_MAXIMUM(1),   0x65,
+    INPUT(1),           0x00,       //   Data,Array,Abs,No Wrap,Linear,Preferred State,No Null Position
+    END_COLLECTION(0)
+};
+
+static uint8_t inputReportData[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+static uint8_t controlPointCommand = 0;
+
+static const HIDInformation HIDInfo[] = {0x0111, 0x00, 0x03};
+
+/// "keys released" report
+static const uint8_t emptyInputReportData[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+/// LEDs report
+static uint8_t outputReportData[] = { 0 };
+
+static const uint16_t uuid16_list[] = {GattService::UUID_HUMAN_INTERFACE_DEVICE_SERVICE};
+
+
+/**
+  * A simple helper function that "returns" our most recently "pressed" key to
+  * the up position.
+  */
+void MicroBitKeyboardService::keyUp()
+{
+    ble.gattServer().write(keyboardInCharacteristic->getValueAttribute().getHandle(), emptyInputReportData, sizeof(emptyInputReportData));
+    fiber_wait_for_event(MICROBIT_ID_NOTIFY, MICROBIT_HID_S_EVT_TX_EMPTY);
+    schedule();
+}
+
+/**
+  * Constructor for our keyboard service.
+  *
+  * Creates a collection of characteristics, instantiates a battery service,
+  * and modifies advertisement data.
+  */
+MicroBitKeyboardService::MicroBitKeyboardService(BLEDevice& _ble)
+: ble(_ble)
+{
+    status = 0;
+
+    GattAttribute inputDescriptor(BLE_UUID_DESCRIPTOR_REPORT_REFERENCE,(uint8_t *)&reports[0], 2, 2);
+    GattAttribute outputDescriptor(BLE_UUID_DESCRIPTOR_REPORT_REFERENCE,(uint8_t *)&reports[1], 2, 2);
+
+    GattAttribute* attrs[] = {
+        (GattAttribute*)&inputDescriptor,
+        (GattAttribute*)&outputDescriptor
+    };
+
+    // stack allocate our characteristics, except for the ones that may require notifications.
+    // here we reuse our outputReportData array which is a single zero byte.
+    GattCharacteristic protocolModeCharacteristic(GattCharacteristic::UUID_PROTOCOL_MODE_CHAR, (uint8_t *)&outputReportData, 1, 1, GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE);
+    keyboardInCharacteristic = new GattCharacteristic(GattCharacteristic::UUID_REPORT_CHAR, (uint8_t *)&inputReportData, sizeof(inputReportData), sizeof(inputReportData),GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE, &attrs[0], 1);
+    GattCharacteristic keyboardOutCharacteristic(GattCharacteristic::UUID_REPORT_CHAR, (uint8_t *)&outputReportData, sizeof(outputReportData), sizeof(outputReportData), GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE, &attrs[1], 1);
+    GattCharacteristic reportMapCharacteristic(GattCharacteristic::UUID_REPORT_MAP_CHAR, (uint8_t *)&reportMap, sizeof(reportMap), sizeof(reportMap), GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ);
+    GattCharacteristic informationCharacteristic(GattCharacteristic::UUID_HID_INFORMATION_CHAR, (uint8_t *)&HIDInfo, sizeof(HIDInformation), sizeof(HIDInformation));
+    GattCharacteristic controlPointCharacteristic(GattCharacteristic::UUID_HID_CONTROL_POINT_CHAR, (uint8_t *)&controlPointCommand, 1, 1, GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE_WITHOUT_RESPONSE);
+
+    GattCharacteristic* characteristics[] = {&informationCharacteristic, &reportMapCharacteristic, &protocolModeCharacteristic, &controlPointCharacteristic, keyboardInCharacteristic, &keyboardOutCharacteristic};
+
+    protocolModeCharacteristic.requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+    keyboardInCharacteristic->requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+    keyboardOutCharacteristic.requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+    reportMapCharacteristic.requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+    informationCharacteristic.requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+    controlPointCharacteristic.requireSecurity(SecurityManager::MICROBIT_BLE_SECURITY_LEVEL);
+
+    GattService service(GattService::UUID_HUMAN_INTERFACE_DEVICE_SERVICE, characteristics, sizeof(characteristics) / sizeof(GattCharacteristic *));
+
+    batteryService = new BatteryService(ble);
+
+    ble.addService(service);
+
+    ble.gattServer().write(keyboardInCharacteristic->getValueHandle(), (uint8_t *)&inputReportData, sizeof(inputReportData));
+
+    ble.gap().stopAdvertising();
+    ble.gap().clearAdvertisingPayload();
+    ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::KEYBOARD);
+
+    ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_16BIT_SERVICE_IDS,(uint8_t *)&uuid16_list, sizeof(uuid16_list));
+    ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE);
+
+    ble.gap().setAdvertisingInterval(MICROBIT_HID_ADVERTISING_INT);
+    ble.gap().startAdvertising();
+}
+
+/**
+  * System tick is used to time the visibility of characters from the HID device.
+  *
+  * Our HID advertising interval is 24 ms, which means there will be a character
+  * swap every 24 ms. Our system tick timer interrupt occures every 6ms...
+  *
+  * After we swap characters, we reset our counter, and emit an event to wake any
+  * waiting fibers.
+  */
+void MicroBitKeyboardService::systemTick()
+{
+    status += 1;
+
+    if(status == MICROBIT_HID_ADVERTISING_INT / SYSTEM_TICK_PERIOD_MS)
+    {
+        status = 0;
+        MicroBitEvent(MICROBIT_ID_NOTIFY, MICROBIT_HID_S_EVT_TX_EMPTY);
+    }
+}
+
+/**
+  * Send a single character to our host.
+  *
+  * @param c the character to send
+  *
+  * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+  */
+int MicroBitKeyboardService::send(const char c)
+{
+    if(!ble.getGapState().connected)
+        return MICROBIT_NOT_SUPPORTED;
+
+    system_timer_add_component(this);
+
+    inputReportData[0] = keymap[(uint8_t)c].modifier;
+    inputReportData[2] = keymap[(uint8_t)c].usage;
+
+    ble.gattServer().write(keyboardInCharacteristic->getValueAttribute().getHandle(), inputReportData, sizeof(inputReportData));
+    fiber_wait_for_event(MICROBIT_ID_NOTIFY, MICROBIT_HID_S_EVT_TX_EMPTY);
+    schedule();
+    keyUp();
+
+    system_timer_remove_component(this);
+
+    return 1;
+}
+
+/**
+  * Send a buffer of characters to our host.
+  *
+  * @param data the characters to send
+  *
+  * @param len the number of characters in the buffer.
+  *
+  * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+  */
+int MicroBitKeyboardService::send(const char* c, int len)
+{
+    int sent = 0;
+    int ret = 0;
+
+    for(int i = 0; i < len; i++)
+    {
+        if((ret = send(c[i])) == MICROBIT_NOT_SUPPORTED)
+            return MICROBIT_NOT_SUPPORTED;
+
+        sent += ret;
+    }
+
+    return sent;
+}
+
+/**
+  * Send a ManagedString to our host.
+  *
+  * @param data the string to send
+  *
+  * @return MICROBIT_NOT_SUPPORTED if the micro:bit is not connected to a host.
+  */
+int MicroBitKeyboardService::send(ManagedString data)
+{
+    return send(data.toCharArray(), data.length());
+}
+
+/**
+  * Destructor.
+  *
+  * Frees our heap allocated characteristic and service, and remove this instance
+  * from our system timer interrupt.
+  */
+MicroBitKeyboardService::~MicroBitKeyboardService()
+{
+    free(batteryService);
+    free(keyboardInCharacteristic);
+    system_timer_remove_component(this);
+}


### PR DESCRIPTION
This commit introduces a lightweight Keyboard HID service that has very simple send operations to the host.

Inspired by the initial pull request of @matthewelse and the sterling work by @jpbrucker .

Points to note:

* as of this morning only tested on my Mac using Just Works pairing, however I would consider this the most difficult scenario based on previous Apple experience.
* It is super RAM efficient, and as a result may not function entirely how a Keyboard HID should, critiques are of course welcome.
* Advertising data is modified in this service, I have yet to determine if this is necessary or not (thoughts @bluetooth-mdw ?)
* The device information service has been modified, and now contains a more RAM efficient version. However, now the device information service will always display the PnPID required as per the HID Bluetooth spec. This shouldn't be harmful to the existing operation of the micro:bit.
* In this service an additional BatteryService is instantiated, as per the HID Bluetooth spec.
