### PR TITLE
Erase scratch pages after use [#286]

### DIFF
--- a/source/drivers/MicroBitFileSystem.cpp
+++ b/source/drivers/MicroBitFileSystem.cpp
@@ -499,6 +499,7 @@ int MicroBitFileSystem::recycleBlock(uint16_t block, int type)
     // Now refresh the page originally holding the block.
     flash.erase_page(page);
     flash.flash_write(page, scratch, PAGE_SIZE);
+    flash.erase_page(scratch);
 
     return MICROBIT_OK;
 }


### PR DESCRIPTION
MicrobitFileSystem occasionally needs to "refresh" FLASH page that have been
marked as deleted, such that they can be used again. When this happens, an
unused FLASH page is used to temporarily hold wanted data (a scratch page).
This is alloctaed ina round robin fashion from all available data pages to
load balance wear across pages.

This patch ensures that a page used in this fashion is erased after use, such
that it is ready for use again as a data page.

This patch may also address https://github.com/Microsoft/pxt/issues/1495