### PR TITLE
Fix compass calibration and improve UX for calibration 'game'

### DIFF
--- a/inc/drivers/MicroBitCompass.h
+++ b/inc/drivers/MicroBitCompass.h
@@ -99,7 +99,8 @@ extern const MAG3110SampleRateConfig MAG3110SampleRate[];
 /**
   * Term to convert sample data into SI units
   */
-#define MAG3110_NORMALIZE_SAMPLE(x) (100*x)
+//#define MAG3110_NORMALIZE_SAMPLE(x) (100*x)
+#define MAG3110_NORMALIZE_SAMPLE(x) (x)
 
 /**
   * MAG3110 MAGIC ID value
@@ -136,6 +137,23 @@ struct CompassSample
     {
         return !(x == other.x && y == other.y && z == other.z);
     }
+
+    int dSquared(CompassSample &s)
+	{
+		return (x - s.x)*(x - s.x) + (y - s.y)*(y - s.y) + (z - s.z)*(z - s.z);
+	}
+};
+
+struct CompassCalibration
+{
+    CompassSample           centre;                  // Zero offset of the compass.
+    CompassSample           scale;                   // Scale factor to apply in each axis to accomodate 1st order directional fields.
+    int                     radius;                  // Indicatoin of field strength - the "distance" from the centre to outmost sample.
+
+    CompassCalibration() : centre(), scale()
+    {
+        radius = 0;
+    }
 };
 
 /**
@@ -149,7 +167,7 @@ class MicroBitCompass : public MicroBitComponent
     uint16_t                address;                  // I2C address of the magnetmometer.
     uint16_t                samplePeriod;             // The time between samples, in millseconds.
 
-    CompassSample           average;                  // Centre point of sample data.
+    CompassCalibration      calibration;              // 
     CompassSample           sample;                   // The latest sample data recorded.
     DigitalIn               int1;                     // Data ready interrupt.
     MicroBitI2C&		    i2c;                      // The I2C interface the sensor is connected to.
@@ -391,7 +409,7 @@ class MicroBitCompass : public MicroBitComponent
       *
       * @param calibration A CompassSample containing the offsets for the x, y and z axis.
       */
-    void setCalibration(CompassSample calibration);
+    void setCalibration(CompassCalibration calibration);
 
     /**
       * Provides the calibration data currently in use by the compass.
@@ -400,7 +418,7 @@ class MicroBitCompass : public MicroBitComponent
       *
       * @return calibration A CompassSample containing the offsets for the x, y and z axis.
       */
-    CompassSample getCalibration();
+    CompassCalibration getCalibration();
 
     /**
       * Updates the local sample, only if the compass indicates that

--- a/inc/drivers/MicroBitCompass.h
+++ b/inc/drivers/MicroBitCompass.h
@@ -99,8 +99,8 @@ extern const MAG3110SampleRateConfig MAG3110SampleRate[];
 /**
   * Term to convert sample data into SI units
   */
-//#define MAG3110_NORMALIZE_SAMPLE(x) (100*x)
-#define MAG3110_NORMALIZE_SAMPLE(x) (x)
+#define MAG3110_UNIT_SCALE 100
+#define MAG3110_NORMALIZE_SAMPLE(x) (MAG3110_UNIT_SCALE*x)
 
 /**
   * MAG3110 MAGIC ID value
@@ -167,7 +167,7 @@ class MicroBitCompass : public MicroBitComponent
     uint16_t                address;                  // I2C address of the magnetmometer.
     uint16_t                samplePeriod;             // The time between samples, in millseconds.
 
-    CompassCalibration      calibration;              // 
+    CompassCalibration      calibration;              // Calibration model of geometry of compass readings
     CompassSample           sample;                   // The latest sample data recorded.
     DigitalIn               int1;                     // Data ready interrupt.
     MicroBitI2C&		    i2c;                      // The I2C interface the sensor is connected to.
@@ -407,7 +407,7 @@ class MicroBitCompass : public MicroBitComponent
       * After calibration this should now take into account trimming errors in the magnetometer,
       * and any "hard iron" offsets on the device.
       *
-      * @param calibration A CompassSample containing the offsets for the x, y and z axis.
+      * @param calibration A CompassCalibration object containing centre, scale and radius in x, y and z.
       */
     void setCalibration(CompassCalibration calibration);
 
@@ -416,7 +416,7 @@ class MicroBitCompass : public MicroBitComponent
       *
       * More specifically, the x, y and z zero offsets of the compass.
       *
-      * @return calibration A CompassSample containing the offsets for the x, y and z axis.
+      * @return calibration A CompassCalibration object containing centre, scale and radius in x, y and z.
       */
     CompassCalibration getCalibration();
 

--- a/inc/drivers/MicroBitCompassCalibrator.h
+++ b/inc/drivers/MicroBitCompassCalibrator.h
@@ -78,7 +78,22 @@ class MicroBitCompassCalibrator
       *
       * This function is, by design, synchronous and only returns once calibration is complete.
       */
-    void calibrate(MicroBitEvent);
+    void calibrateUX(MicroBitEvent);
+     /**
+      * Calculates an independent X, Y, Z scale factor and centre for a given set of data points,
+      * assumed to be on a bounding sphere
+      *
+      * @param data An array of all data points
+      * @param samples The number of samples in the 'data' array.
+      *
+      * This algorithm should be called with no fewer than 12 points, but testing has indicated >21
+      * points provides a more robust calculation.
+      *
+      * @return A calibration structure containing the a calculated centre point, the radius of the
+      * minimum enclosing spere of points and a scaling factor for each axis that places those
+      * points as close as possible to the surface of the containing sphere.
+      */
+     static CompassCalibration calibrate(CompassSample *data, int samples);
 
     private:
 
@@ -91,7 +106,7 @@ class MicroBitCompassCalibrator
      *
      * @return The deviation between the closest and further point in the data array from the point given. 
      */
-    int measureScore(CompassSample &c, CompassSample *data, int samples);
+    static int measureScore(CompassSample &c, CompassSample *data, int samples);
 
     /*
      * Performs an interative approximation (hill descent) algorithm to determine an
@@ -102,7 +117,7 @@ class MicroBitCompassCalibrator
      *
      * @return the approximated centre point of the points in the 'data' array.
      */
-    CompassSample approximateCentre(CompassSample *data, int samples);
+    static CompassSample approximateCentre(CompassSample *data, int samples);
 
     /**
      * Calculates an independent scale factor for X,Y and Z axes that places the given data points on a bounding sphere
@@ -115,7 +130,7 @@ class MicroBitCompassCalibrator
      * enclosing spere of points and a scaling factor for each axis that places those points as close as possible
      * to the surface of the containing sphere.
      */
-    CompassCalibration spherify(CompassSample centre, CompassSample *data, int samples);
+    static CompassCalibration spherify(CompassSample centre, CompassSample *data, int samples);
 };
 
 #endif

--- a/inc/drivers/MicroBitCompassCalibrator.h
+++ b/inc/drivers/MicroBitCompassCalibrator.h
@@ -79,6 +79,43 @@ class MicroBitCompassCalibrator
       * This function is, by design, synchronous and only returns once calibration is complete.
       */
     void calibrate(MicroBitEvent);
+
+    private:
+
+    /**
+     * Scoring function for a hill climb algorithm.
+     *
+     * @param c An approximated centre point
+     * @param data a collection of data points
+     * @param samples the number of samples in the 'data' array
+     *
+     * @return The deviation between the closest and further point in the data array from the point given. 
+     */
+    int measureScore(CompassSample &c, CompassSample *data, int samples);
+
+    /*
+     * Performs an interative approximation (hill descent) algorithm to determine an
+     * estimated centre point of a sphere upon which the given data points reside.
+     *
+     * @param data an array containing sample points
+     * @param samples the number of sample points in the 'data' array.
+     *
+     * @return the approximated centre point of the points in the 'data' array.
+     */
+    CompassSample approximateCentre(CompassSample *data, int samples);
+
+    /**
+     * Calculates an independent scale factor for X,Y and Z axes that places the given data points on a bounding sphere
+     *
+     * @param centre A proviously calculated centre point of all data.
+     * @param data An array of all data points
+     * @param samples The number of samples in the 'data' array.
+     *
+     * @return A calibration structure containing the centre point provided, the radius of the minimum
+     * enclosing spere of points and a scaling factor for each axis that places those points as close as possible
+     * to the surface of the containing sphere.
+     */
+    CompassCalibration spherify(CompassSample centre, CompassSample *data, int samples);
 };
 
 #endif

--- a/source/drivers/MicroBitCompass.cpp
+++ b/source/drivers/MicroBitCompass.cpp
@@ -306,24 +306,6 @@ int MicroBitCompass::read8(uint8_t reg)
   */
 int MicroBitCompass::tiltCompensatedBearing()
 {
-#ifdef OLD
-    // Precompute the tilt compensation parameters to improve readability.
-    float phi = accelerometer->getRollRadians();
-    float theta = accelerometer->getPitchRadians();
-
-    float x = (float) getX(NORTH_EAST_DOWN);
-    float y = (float) getY(NORTH_EAST_DOWN);
-    float z = (float) getZ(NORTH_EAST_DOWN);
-
-    // Precompute cos and sin of pitch and roll angles to make the calculation a little more efficient.
-    float sinPhi = sin(phi);
-    float cosPhi = cos(phi);
-    float sinTheta = sin(theta);
-    float cosTheta = cos(theta);
-
-    float bearing = (360*atan2(z*sinPhi - y*cosPhi, x*cosTheta + y*sinTheta*sinPhi + z*sinTheta*cosPhi)) / (2*PI);
-#endif
-
     float x = (float) getX(NORTH_EAST_DOWN);
     float y = (float) getY(NORTH_EAST_DOWN);
     float z = (float) getZ(NORTH_EAST_DOWN);
@@ -723,7 +705,7 @@ int MicroBitCompass::calibrate()
   * After calibration this should now take into account trimming errors in the magnetometer,
   * and any "hard iron" offsets on the device.
   *
-  * @param calibration A CompassCalibration containing the offsets for the x, y and z axis and scaling data.
+  * @param calibration A CompassCalibration object containing centre, scale and radius in x, y and z.
   */
 void MicroBitCompass::setCalibration(CompassCalibration calibration)
 {
@@ -739,7 +721,7 @@ void MicroBitCompass::setCalibration(CompassCalibration calibration)
   *
   * More specifically, the x, y and z zero offsets of the compass.
   *
-  * @return calibration A CompassCalibration containing the offsets for the x, y and z axis and per axis scaling data.
+  * @return calibration A CompassCalibration object containing centre, scale and radius in x, y and z.
   */
 CompassCalibration MicroBitCompass::getCalibration()
 {

--- a/source/drivers/MicroBitCompass.cpp
+++ b/source/drivers/MicroBitCompass.cpp
@@ -34,6 +34,11 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitFiber.h"
 #include "ErrorNo.h"
 
+//
+// Internal convenience macro to apply calibration to a given sample.
+//
+#define CALIBRATED_SAMPLE(sample, axis) (((sample.axis - calibration.centre.axis) * calibration.scale.axis) >> 10)
+
 /**
   * An initialisation member function used by the many constructors of MicroBitCompass.
   *
@@ -59,12 +64,8 @@ void MicroBitCompass::init(uint16_t id, uint16_t address)
 
         if(calibrationData != NULL)
         {
-            CompassSample storedSample = CompassSample();
-
-            memcpy(&storedSample, calibrationData->value, sizeof(CompassSample));
-
-            setCalibration(storedSample);
-
+            memcpy(&calibration, calibrationData->value, sizeof(CompassCalibration));
+            status |= MICROBIT_COMPASS_STATUS_CALIBRATED;
             delete calibrationData;
         }
     }
@@ -98,7 +99,7 @@ void MicroBitCompass::init(uint16_t id, uint16_t address)
   * @endcode
   */
 MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitAccelerometer& _accelerometer, MicroBitStorage& _storage, uint16_t address,  uint16_t id) :
-    average(),
+    calibration(),
     sample(),
     int1(MICROBIT_PIN_COMPASS_DATA_READY),
     i2c(_i2c),
@@ -129,7 +130,7 @@ MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitAccelerometer& _acce
   * @endcode
   */
 MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitAccelerometer& _accelerometer, uint16_t address, uint16_t id) :
-    average(),
+    calibration(),
     sample(),
     int1(MICROBIT_PIN_COMPASS_DATA_READY),
     i2c(_i2c),
@@ -160,7 +161,7 @@ MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitAccelerometer& _acce
   * @endcode
   */
 MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitStorage& _storage, uint16_t address, uint16_t id) :
-    average(),
+    calibration(),
     sample(),
     int1(MICROBIT_PIN_COMPASS_DATA_READY),
     i2c(_i2c),
@@ -187,7 +188,7 @@ MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, MicroBitStorage& _storage, u
   * @endcode
   */
 MicroBitCompass::MicroBitCompass(MicroBitI2C& _i2c, uint16_t address, uint16_t id) :
-    average(),
+    calibration(),
     sample(),
     int1(MICROBIT_PIN_COMPASS_DATA_READY),
     i2c(_i2c),
@@ -305,6 +306,7 @@ int MicroBitCompass::read8(uint8_t reg)
   */
 int MicroBitCompass::tiltCompensatedBearing()
 {
+#ifdef OLD
     // Precompute the tilt compensation parameters to improve readability.
     float phi = accelerometer->getRollRadians();
     float theta = accelerometer->getPitchRadians();
@@ -320,11 +322,34 @@ int MicroBitCompass::tiltCompensatedBearing()
     float cosTheta = cos(theta);
 
     float bearing = (360*atan2(z*sinPhi - y*cosPhi, x*cosTheta + y*sinTheta*sinPhi + z*sinTheta*cosPhi)) / (2*PI);
+#endif
+
+    float x = (float) getX(NORTH_EAST_DOWN);
+    float y = (float) getY(NORTH_EAST_DOWN);
+    float z = (float) getZ(NORTH_EAST_DOWN);
+
+    float ax = (float) accelerometer->getX(NORTH_EAST_DOWN);
+    float ay = (float) accelerometer->getY(NORTH_EAST_DOWN);
+    float az = (float) accelerometer->getZ(NORTH_EAST_DOWN);
+
+    // normalize the readings
+    float amag = sqrt(ax*ax + ay*ay + az*az);
+    ax = ax/amag;
+    ay = ay/amag;
+    az = az/amag;
+
+    float ax2 = ax*ax;
+    float ay2 = ay*ay;
+
+    float resultx = x*(1.0f - ax2) - y*ax*ay - z*ax*sqrt(1.0f-ax2-ay2);
+    float resulty = y*sqrt(1.0f-ax2-ay2) - z*ay;
+
+    float bearing = (360*atan2(resulty,resultx)) / (2*PI);
 
     if (bearing < 0)
         bearing += 360.0;
 
-    return (int) bearing;
+    return (int) (360.0 - bearing);
 }
 
 /**
@@ -334,7 +359,7 @@ int MicroBitCompass::basicBearing()
 {
     updateSample();
 
-    float bearing = (atan2((double)(sample.y - average.y),(double)(sample.x - average.x)))*180/PI;
+    float bearing = (atan2((double)getY(),(double)getX()))*180/PI;
 
     if (bearing < 0)
         bearing += 360.0;
@@ -433,10 +458,10 @@ int MicroBitCompass::getX(MicroBitCoordinateSystem system)
     switch (system)
     {
         case SIMPLE_CARTESIAN:
-            return sample.x - average.x;
+            return CALIBRATED_SAMPLE(sample, x);
 
         case NORTH_EAST_DOWN:
-            return -(sample.y - average.y);
+            return -CALIBRATED_SAMPLE(sample, y);
 
         case RAW:
         default:
@@ -462,10 +487,10 @@ int MicroBitCompass::getY(MicroBitCoordinateSystem system)
     switch (system)
     {
         case SIMPLE_CARTESIAN:
-            return -(sample.y - average.y);
+            return -CALIBRATED_SAMPLE(sample, y);
 
         case NORTH_EAST_DOWN:
-            return (sample.x - average.x);
+            return CALIBRATED_SAMPLE(sample, x);
 
         case RAW:
         default:
@@ -492,7 +517,7 @@ int MicroBitCompass::getZ(MicroBitCoordinateSystem system)
     {
         case SIMPLE_CARTESIAN:
         case NORTH_EAST_DOWN:
-            return -(sample.z - average.z);
+            return -CALIBRATED_SAMPLE(sample, z);
 
         case RAW:
         default:
@@ -698,14 +723,14 @@ int MicroBitCompass::calibrate()
   * After calibration this should now take into account trimming errors in the magnetometer,
   * and any "hard iron" offsets on the device.
   *
-  * @param calibration A CompassSample containing the offsets for the x, y and z axis.
+  * @param calibration A CompassCalibration containing the offsets for the x, y and z axis and scaling data.
   */
-void MicroBitCompass::setCalibration(CompassSample calibration)
+void MicroBitCompass::setCalibration(CompassCalibration calibration)
 {
     if(this->storage != NULL)
-        this->storage->put(ManagedString("compassCal"), (uint8_t *)&calibration, sizeof(CompassSample));
+        this->storage->put(ManagedString("compassCal"), (uint8_t *)&calibration, sizeof(CompassCalibration));
 
-    average = calibration;
+    this->calibration = calibration;
     status |= MICROBIT_COMPASS_STATUS_CALIBRATED;
 }
 
@@ -714,11 +739,11 @@ void MicroBitCompass::setCalibration(CompassSample calibration)
   *
   * More specifically, the x, y and z zero offsets of the compass.
   *
-  * @return calibration A CompassSample containing the offsets for the x, y and z axis.
+  * @return calibration A CompassCalibration containing the offsets for the x, y and z axis and per axis scaling data.
   */
-CompassSample MicroBitCompass::getCalibration()
+CompassCalibration MicroBitCompass::getCalibration()
 {
-    return average;
+    return calibration;
 }
 
 /**

--- a/source/drivers/MicroBitCompassCalibrator.cpp
+++ b/source/drivers/MicroBitCompassCalibrator.cpp
@@ -364,8 +364,8 @@ void MicroBitCompassCalibrator::calibrateUX(MicroBitEvent)
                 samples_this_period++;
             }
         }
-        wait_ms(100);
-        remaining_scroll_time-=100;
+        wait_ms(TIME_STEP);
+        remaining_scroll_time-=TIME_STEP;
     }
 
     compass.setCalibration(calibrate(data, samples));

--- a/source/drivers/MicroBitCompassCalibrator.cpp
+++ b/source/drivers/MicroBitCompassCalibrator.cpp
@@ -52,6 +52,307 @@ MicroBitCompassCalibrator::MicroBitCompassCalibrator(MicroBitCompass& _compass, 
 }
 
 /**
+ * Scoring function for a hill climb algorithm.
+ *
+ * @param c An approximated centre point
+ * @param data a collection of data points
+ * @param samples the number of samples in the 'data' array
+ *
+ * @return The deviation between the closest and further point in the data array from the point given. 
+ */
+int MicroBitCompassCalibrator::measureScore(CompassSample &c, CompassSample *data, int samples)
+{
+    int minD;
+    int maxD;
+
+    minD = maxD = c.dSquared(data[0]);
+    for (int i = 1; i < samples; i++)
+    {
+        int d = c.dSquared(data[i]);
+
+        if (d < minD)
+            minD = d;
+
+        if (d > maxD)
+            maxD = d;
+    }
+
+    return (maxD - minD);
+}
+
+/**
+ * Calculates an independent scale factor for X,Y and Z axes that places the given data points on a bounding sphere
+ *
+ * @param centre A proviously calculated centre point of all data.
+ * @param data An array of all data points
+ * @param samples The number of samples in the 'data' array.
+ *
+ * @return A calibration structure containing the centre point provided, the radius of the minimum
+ * enclosing spere of points and a scaling factor for each axis that places those points as close as possible
+ * to the surface of the containing sphere.
+ */
+CompassCalibration MicroBitCompassCalibrator::spherify(CompassSample centre, CompassSample *data, int samples)
+{
+    // First, determine the radius of the enclosing sphere from the given centre.
+    // n.b. this will likely be different to the radius from the centre of mass previously calculated.
+    // We use the same algorithm though.
+    CompassCalibration result;
+
+    float radius = 0;
+    float scaleX = 0.0;
+    float scaleY = 0.0;
+    float scaleZ = 0.0;
+
+    float scale = 0.0;
+    float weightX = 0.0;
+    float weightY = 0.0;
+    float weightZ = 0.0;
+
+    for (int i = 0; i < samples; i++)
+    {
+        int d = sqrt((float)centre.dSquared(data[i]));
+
+        if (d > radius)
+            radius = d;
+    }
+
+    // Now, for each data point, determine a scalar multiplier for the vector between the centre and that point that
+    // takes the point onto the surface of the enclosing sphere.
+    for (int i = 0; i < samples; i++)
+    {
+        // Calculate the distance from this point to the centre of the sphere
+        float d = sqrt(centre.dSquared(data[i]));
+
+        // Now determine a scalar multiplier that, when applied to the vector to the centre,
+        // will place this point on the surface of the sphere.
+        float s = (radius / d) - 1;
+
+        scale = max(scale, s);
+
+        // next, determine the scale effect this has on each of our components.
+        float dx = (data[i].x - centre.x); 
+        float dy = (data[i].y - centre.y);
+        float dz = (data[i].z - centre.z);
+
+        weightX += s * fabsf(dx / d);
+        weightY += s * fabsf(dy / d);
+        weightZ += s * fabsf(dz / d);
+    }
+
+    float wmag = sqrt((weightX * weightX) + (weightY * weightY) + (weightZ * weightZ));
+
+    scaleX = 1.0 + scale * (weightX / wmag);
+    scaleY = 1.0 + scale * (weightY / wmag);
+    scaleZ = 1.0 + scale * (weightZ / wmag);
+
+    result.scale.x = (int)(1024 * scaleX);
+    result.scale.y = (int)(1024 * scaleY);
+    result.scale.z = (int)(1024 * scaleZ);
+
+    result.centre.x = centre.x;
+    result.centre.y = centre.y;
+    result.centre.z = centre.z;
+
+    result.radius = radius;
+
+    return result;
+}
+
+/*
+ * Performs an interative approximation (hill descent) algorithm to determine an
+ * estimated centre point of a sphere upon which the given data points reside.
+ *
+ * @param data an array containing sample points
+ * @param samples the number of sample points in the 'data' array.
+ *
+ * @return the approximated centre point of the points in the 'data' array.
+ */
+CompassSample MicroBitCompassCalibrator::approximateCentre(CompassSample *data, int samples)
+{
+    CompassSample c,t;
+    CompassSample centre = { 0,0,0 };
+    CompassSample best = { 0,0,0 };
+
+    int score;
+
+    for (int i = 0; i < samples; i++)
+    {
+        centre.x += data[i].x;
+        centre.y += data[i].y;
+        centre.z += data[i].z;
+    }
+
+    // Calclulate a centre of mass for our input samples. We only use this for validation purposes.
+    centre.x = centre.x / samples;
+    centre.y = centre.y / samples;
+    centre.z = centre.z / samples;
+
+    // Start hill climb in the centre of mass.
+    c = centre;
+
+    // calculate the nearest and furthest point to us.
+    score = measureScore(c, data, samples);
+
+    // iteratively attempt to improve position...
+    while (1)
+    {
+        for (int x = -1; x <= 1; x++)
+        {
+            for (int y = -1; y <= 1; y++)
+            {
+                for (int z = -1; z <= 1; z++)
+                {
+                    t = c;
+                    t.x += x;
+                    t.y += y;
+                    t.z += z;
+
+                    int s = measureScore(t, data, samples);
+                    if (s < score)
+                    {
+                        score = s;
+                        best = t;
+                    }
+                }
+            }
+        }
+
+        if (best.x == c.x && best.y == c.y && best.z == c.z)
+            break;
+
+        c = best;
+    }
+
+    return c;
+}
+
+/**
+ * Performs a simple game that in parallel, calibrates the compass.
+ *
+ * This function is executed automatically when the user requests a compass bearing, and compass calibration is required.
+ *
+ * This function is, by design, synchronous and only returns once calibration is complete.
+ */
+void MicroBitCompassCalibrator::calibrate(MicroBitEvent)
+{
+    struct Point
+    {
+        uint8_t x;
+        uint8_t y;
+        uint8_t on;
+    };
+
+    //const int PERIMETER_POINTS = 21;
+    const int PERIMETER_POINTS = 12;
+
+    const int PIXEL1_THRESHOLD = 200;
+    const int PIXEL2_THRESHOLD = 800;
+
+    wait_ms(100);
+
+    //Point perimeter[PERIMETER_POINTS] = {{1,0,0}, {2,0,0}, {3,0,0}, {0,1,0}, {1,1,0}, {2,1,0}, {3,1,0}, {4,1,0}, {0,2,0}, {1,2,0}, {2,2,0}, {3,2,0}, {4,2,0}, {0,3,0}, {1,3,0}, {2,3,0}, {3,3,0}, {4,3,0}, {1,4,0}, {2,4,0}, {3,4,0}};
+    Point perimeter[PERIMETER_POINTS] = {{1,0,0}, {2,0,0}, {3,0,0}, {4,1,0}, {4,2,0}, {4,3,0}, {3,4,0}, {2,4,0}, {1,4,0}, {0,3,0}, {0,2,0}, {0,1,0}};
+    Point cursor = {2,2,0};
+
+    MicroBitImage img(5,5);
+    MicroBitImage smiley("0,255,0,255,0\n0,255,0,255,0\n0,0,0,0,0\n255,0,0,0,255\n0,255,255,255,0\n");
+
+    CompassSample data[PERIMETER_POINTS];
+    int samples = 0;
+
+    // Firstly, we need to take over the display. Ensure all active animations are paused.
+    display.stopAnimation();
+    display.scrollAsync("TILT A CIRCLE");
+
+    for (int i=0; i<110; i++)
+        wait_ms(100);
+
+    display.stopAnimation();
+    display.clear();
+
+    while(samples < PERIMETER_POINTS)
+    {
+        // update our model of the flash status of the user controlled pixel.
+        cursor.on = (cursor.on + 1) % 4;
+
+        // take a snapshot of the current accelerometer data.
+        int x = accelerometer.getX();
+        int y = accelerometer.getY();
+
+        // Wait a little whie for the button state to stabilise (one scheduler tick).
+        wait_ms(10);
+
+        // Deterine the position of the user controlled pixel on the screen.
+        if (x < -PIXEL2_THRESHOLD)
+            cursor.x = 0;
+        else if (x < -PIXEL1_THRESHOLD)
+            cursor.x = 1;
+        else if (x > PIXEL2_THRESHOLD)
+            cursor.x = 4;
+        else if (x > PIXEL1_THRESHOLD)
+            cursor.x = 3;
+        else
+            cursor.x = 2;
+
+        if (y < -PIXEL2_THRESHOLD)
+            cursor.y = 0;
+        else if (y < -PIXEL1_THRESHOLD)
+            cursor.y = 1;
+        else if (y > PIXEL2_THRESHOLD)
+            cursor.y = 4;
+        else if (y > PIXEL1_THRESHOLD)
+            cursor.y = 3;
+        else
+            cursor.y = 2;
+
+        img.clear();
+
+        // Turn on any pixels that have been visited.
+        for (int i=0; i<PERIMETER_POINTS; i++)
+            if (perimeter[i].on)
+                img.setPixelValue(perimeter[i].x, perimeter[i].y, 255);
+
+        // Update the pixel at the users position.
+        img.setPixelValue(cursor.x, cursor.y, 255);
+
+        // Update the buffer to the screen.
+        display.image.paste(img,0,0,0);
+
+        // test if we need to update the state at the users position.
+        for (int i=0; i<PERIMETER_POINTS; i++)
+        {
+            if (cursor.x == perimeter[i].x && cursor.y == perimeter[i].y && !perimeter[i].on)
+            {
+                // Record the sample data for later processing...
+                data[samples].x = compass.getX(RAW);
+                data[samples].y = compass.getY(RAW);
+                data[samples].z = compass.getZ(RAW);
+
+                // Record that this pixel has been visited.
+                perimeter[i].on = 1;
+                samples++;
+            }
+        }
+
+        wait_ms(100);
+    }
+
+    CompassSample centre = approximateCentre(data, samples);
+    CompassCalibration cal = spherify(centre, data, samples);
+    compass.setCalibration(cal);
+
+    // Show a smiley to indicate that we're done, and continue on with the user program.
+    display.clear();
+    display.printAsync(smiley, 0, 0, 0, 1500);
+    wait_ms(1000);
+    display.clear();
+}
+
+
+
+
+#ifdef OLD_CALIBRATION
+/**
   * Performs a simple game that in parallel, calibrates the compass.
   *
   * This function is executed automatically when the user requests a compass bearing, and compass calibration is required.
@@ -186,3 +487,5 @@ void MicroBitCompassCalibrator::calibrate(MicroBitEvent)
     wait_ms(1000);
     display.clear();
 }
+
+#endif


### PR DESCRIPTION
This PR brings in Joe's fixed compass calibration routine developed in #288 and adds the 'tilt to fill screen' compass calibration routine.

There will be a number of knock-on effects of changing this for documentation, so @microbit-mark and @whaleygeek here's a heads up - we can merge to master before doing this but I think the change shouldn't hit microbit live editors until we've made updates.

- [x] Update micro:bit knowledge base: https://support.microbit.org/support/solutions/articles/19000008874-calibrating-the-micro-bit-compass-what-does-it-mean-when-the-micro-bit-says-draw-a-circle-or-tilt
- [x] Update MakeCode page (https://makecode.microbit.org/reference/input/calibrate-compass )
- [ ] Liaise with @dpgeorge about the right approach to integrating this with MicroPython so we make the change at about the same time (still considering a separate patch to break out the calibration from the UX)
- [ ] Wider testing
 
