### PR TITLE
Rewrite MicroBitImage parsing code so it doesn't depend on atoi()

### DIFF
--- a/source/types/MicroBitImage.cpp
+++ b/source/types/MicroBitImage.cpp
@@ -117,10 +117,8 @@ MicroBitImage::MicroBitImage(const char *s)
     int count = 0;
     int digit = 0;
 
-    char parseBuf[10];
-
     const char *parseReadPtr;
-    char *parseWritePtr;
+    int parseValue;
     uint8_t *bitmapPtr;
 
     if (s == NULL)
@@ -169,24 +167,26 @@ MicroBitImage::MicroBitImage(const char *s)
 
     // Second pass: collect the data.
     parseReadPtr = s;
-    parseWritePtr = parseBuf;
+    parseValue = -1;
     bitmapPtr = this->getBitmap();
 
     while (*parseReadPtr)
     {
         if (isdigit(*parseReadPtr))
         {
-            *parseWritePtr = *parseReadPtr;
-            parseWritePtr++;
+            if (parseValue < 0)
+            {
+                parseValue = 0;
+            }
+            parseValue = parseValue * 10 + *parseReadPtr - '0';
         }
         else
         {
-            *parseWritePtr = 0;
-            if (parseWritePtr > parseBuf)
+            if (parseValue >= 0)
             {
-                *bitmapPtr = atoi(parseBuf);
+                *bitmapPtr = parseValue;
                 bitmapPtr++;
-                parseWritePtr = parseBuf;
+                parseValue = -1;
             }
         }
 


### PR DESCRIPTION
Using the function atoi() pulls in a dependency from newlib, which in turn
pulls in locale support, and locale support requires about 350 bytes of
RAM.  This patch removes such a dependency by rewriting the MicroBitImage
parsing code so that it directly converts the input string to an integer
instead of building a buffer and passing it to atoi().

This patch saves about 640 bytes of code space and 364 bytes of RAM.  It
also reduces the amount of stack space used by the MicroBitImage
constructor.

See #323 for further discussion.