### PR TITLE
Remove "throw" exception specifications because they are deprecated.

### DIFF
--- a/inc/core/MicroBitHeapAllocator.h
+++ b/inc/core/MicroBitHeapAllocator.h
@@ -136,7 +136,7 @@ inline void native_free(void *p)
 /**
   * Overrides the 'new' operator globally, and redirects calls to the micro:bit heap allocator.
   */
-inline void* operator new(size_t size) throw(std::bad_alloc)
+inline void* operator new(size_t size)
 {
     return microbit_malloc(size);
 }
@@ -144,7 +144,7 @@ inline void* operator new(size_t size) throw(std::bad_alloc)
 /**
   * Overrides the 'new' operator globally, and redirects calls to the micro:bit theap allocator.
   */
-inline void* operator new[](size_t size) throw(std::bad_alloc)
+inline void* operator new[](size_t size)
 {
     return microbit_malloc(size);
 }
@@ -152,7 +152,7 @@ inline void* operator new[](size_t size) throw(std::bad_alloc)
 /**
   * Overrides the 'delete' operator globally, and redirects calls to the micro:bit theap allocator.
   */
-inline void operator delete(void *ptr) throw()
+inline void operator delete(void *ptr)
 {
     microbit_free(ptr);
 }


### PR DESCRIPTION
The use of such specifications are deprecated since C++11, see for example https://stackoverflow.com/questions/13841559/deprecated-throw-list-in-c11.  Having these specifications here leads to lots of warnings on modern C++ compilers (eg arm-none-eabi-gcc v7.2.0).