### PR TITLE
Appended asterisk to device name characteristic when in pairing mode

### DIFF
--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -667,6 +667,7 @@ void MicroBitBLEManager::pairingMode(MicroBitDisplay &display, MicroBitButton &a
     ble->accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LOCAL_NAME, (uint8_t *)BLEName.toCharArray(), BLEName.length());
     ble->setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
     ble->setAdvertisingInterval(200);
+    ble->gap().setDeviceName((uint8_t *)(BLEName + "*").toCharArray());
 
     ble->gap().setAdvertisingTimeout(0);
     ble->gap().startAdvertising();


### PR DESCRIPTION
It's sometimes useful to be able to detect if the connected micro:bit is in pairing mode. By appending "*" to the device name characteristic in the Generic Access Service when in pairing mode, connected applications can identify this condition.