### PR TITLE
Add SoftDevice values for S130v1

### DIFF
--- a/inc/core/MicroBitConfig.h
+++ b/inc/core/MicroBitConfig.h
@@ -49,12 +49,20 @@ DEALINGS IN THE SOFTWARE.
 
 // The end address of memory normally reserved for Soft Device.
 #ifndef MICROBIT_SD_LIMIT
+#ifdef TARGET_MCU_NRF51_16K_S130
+#define MICROBIT_SD_LIMIT                       0x20002800
+#else
 #define MICROBIT_SD_LIMIT                       0x20002000
+#endif
 #endif
 
 // The physical address in memory of the Soft Device GATT table.
 #ifndef MICROBIT_SD_GATT_TABLE_START
+#ifdef TARGET_MCU_NRF51_16K_S130
+#define MICROBIT_SD_GATT_TABLE_START            0x20002200
+#else
 #define MICROBIT_SD_GATT_TABLE_START            0x20001900
+#endif
 #endif
 
 // Physical address of the top of the system stack (on mbed-classic this is the top of SRAM)


### PR DESCRIPTION
These values are determined from
http://infocenter.nordicsemi.com/pdf/S130_SDS_v1.0.pdf
pg 41

It appears using S130v2 would allow even lower memory consumption

This is for use in conjunction with the
bbc-microbot-classic-gcc-s130
target, which also needs a fix before it will work.