### PR TITLE
Fixed sample period lookup issue in MAG3110 and MMA8653 drivers.

### DIFF
--- a/source/drivers/MAG3110.cpp
+++ b/source/drivers/MAG3110.cpp
@@ -99,7 +99,7 @@ int MAG3110::configure()
 
 
     // Bring the device online, with the requested sample frequency.
-    result = i2c.writeRegister(address, MAG_CTRL_REG1, magnetometerPeriod.get(samplePeriod) | 0x01);
+    result = i2c.writeRegister(address, MAG_CTRL_REG1, magnetometerPeriod.get(samplePeriod * 1000) | 0x01);
     if (result != MICROBIT_OK)
         return MICROBIT_I2C_ERROR;
 

--- a/source/drivers/MMA8653.cpp
+++ b/source/drivers/MMA8653.cpp
@@ -130,7 +130,7 @@ int MMA8653::configure()
         return MICROBIT_I2C_ERROR;
 
     // Bring the device back online, with 10bit wide samples at the requested frequency.
-    value = accelerometerPeriod.get(samplePeriod);
+    value = accelerometerPeriod.get(samplePeriod * 1000);
     result = i2c.writeRegister(address, MMA8653_CTRL_REG1, value | 0x01);
     if (result != 0)
         return MICROBIT_I2C_ERROR;

--- a/source/drivers/MicroBitCompass.cpp
+++ b/source/drivers/MicroBitCompass.cpp
@@ -79,8 +79,8 @@ void MicroBitCompass::init(uint16_t id)
     this->id = id;
     this->status = 0;
 
-    // Set a default rate of 50Hz.
-    this->samplePeriod = 20;
+    // Set a default rate of 10Hz.
+    this->samplePeriod = 100;
     this->configure();
 
     // Assume that we have no calibration information.


### PR DESCRIPTION
After performing many tests on various micro:bit revs. it was apparent that the 1.3 board was consuming 1600uA under an idle test using a lite version of the dal-integration branch. 

Under further inspection, the issue was found with the sample period lookup not being multiplied by 1000 when writing the configuration to the device. Also, I have set the default magnetometer sample rate back to 10Hz to match the values found in the current master branch.

This fix reduces the power consumption by around 700uA, leaving the 1.3 boards running at 900uA under this same idle test.

