### PR TITLE
Always read from the serial to clear the RX interrupt

### DIFF
--- a/source/drivers/MicroBitSerial.cpp
+++ b/source/drivers/MicroBitSerial.cpp
@@ -88,11 +88,12 @@ MicroBitSerial::MicroBitSerial(PinName tx, PinName rx, uint8_t rxBufferSize, uin
   */
 void MicroBitSerial::dataReceived()
 {
+    //get the received character
+    //Note: always read from the serial to clear the RX interrupt
+    char c = getc();
+
     if(!(status & MICROBIT_SERIAL_RX_BUFF_INIT))
         return;
-
-    //get the received character
-    char c = getc();
 
     int delimeterOffset = 0;
     int delimLength = this->delimeters.length();


### PR DESCRIPTION
The Micro:bit crashes if the RX buffer is not initialized when data is received. The cause is that the RX interrupt is not cleared in this case.

This problem always appears after a redirect without any read operation.

Fixes https://github.com/Microsoft/pxt-microbit/issues/917
Potential fix for #152