### PR TITLE
Determine micro:bit model version and add to Device Information Service

### DIFF
--- a/inc/bluetooth/MicroBitBLEManager.h
+++ b/inc/bluetooth/MicroBitBLEManager.h
@@ -150,7 +150,7 @@ class MicroBitBLEManager : MicroBitComponent
       * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true);
       * @endcode
       */
-    void init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, bool enableBonding);
+    void init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, bool enableBonding, ManagedString microbitModel = ManagedString("BBC micro:bit"));
 
     /**
      * Change the output power level of the transmitter to the given value.
@@ -323,6 +323,8 @@ class MicroBitBLEManager : MicroBitComponent
      * This variable will be set to MICROBIT_MODE_PAIRING if pairingMode() is executed.
      */
     uint8_t currentMode = MICROBIT_MODE_APPLICATION;
+
+    char* getMicrobitModel();
 
 };
 

--- a/inc/core/MicroBitDevice.h
+++ b/inc/core/MicroBitDevice.h
@@ -38,6 +38,10 @@ DEALINGS IN THE SOFTWARE.
 #define MICROBIT_NAME_CODE_LETTERS              5
 #define MICROBIT_PANIC_ERROR_CHARS              4
 
+#define MICROBIT_MODEL_UNKNOWN                  "BBC micro:bit"
+#define MICROBIT_MODEL_1_3_X                    "BBC micro:bit v1.3x"
+#define MICROBIT_MODEL_1_5_X                    "BBC micro:bit v1.5"
+
 #include "MicroBitConfig.h"
 #include "MicroBitMatrixMaps.h"
 

--- a/inc/drivers/FXOS8700.h
+++ b/inc/drivers/FXOS8700.h
@@ -232,6 +232,13 @@ class FXOS8700 : public MicroBitAccelerometer, public MicroBitCompass
     virtual void idleTick();
 
     /**
+    * Returns which accelerometer is detected
+    *
+    * @return MICROBIT_ACCELEROMETER_XXX
+    */
+    virtual uint8_t whatAmI();
+
+    /**
      * Destructor.
      */
     ~FXOS8700();

--- a/inc/drivers/LSM303Accelerometer.h
+++ b/inc/drivers/LSM303Accelerometer.h
@@ -148,6 +148,13 @@ class LSM303Accelerometer : public MicroBitAccelerometer
     static int isDetected(MicroBitI2C &i2c, uint16_t address = LSM303_A_DEFAULT_ADDR);
 
     /**
+    * Returns which accelerometer is detected
+    *
+    * @return MICROBIT_ACCELEROMETER_XXX
+    */
+    virtual uint8_t whatAmI();
+
+    /**
      * Destructor.
      */
     ~LSM303Accelerometer();

--- a/inc/drivers/MMA8653.h
+++ b/inc/drivers/MMA8653.h
@@ -123,6 +123,12 @@ class MMA8653 : public MicroBitAccelerometer
      */
     static int isDetected(MicroBitI2C &i2c, uint16_t address = MMA8653_DEFAULT_ADDR);
 
+    /**
+    * Returns which accelerometer is detected
+    *
+    * @return MICROBIT_ACCELEROMETER_XXX
+    */
+    virtual uint8_t whatAmI();
 
     /**
      * Destructor.

--- a/inc/drivers/MicroBitAccelerometer.h
+++ b/inc/drivers/MicroBitAccelerometer.h
@@ -79,6 +79,11 @@ DEALINGS IN THE SOFTWARE.
 #define MICROBIT_ACCELEROMETER_8G_THRESHOLD                 ((uint32_t)MICROBIT_ACCELEROMETER_8G_TOLERANCE * (uint32_t)MICROBIT_ACCELEROMETER_8G_TOLERANCE)
 #define MICROBIT_ACCELEROMETER_SHAKE_COUNT_THRESHOLD        4
 
+#define MICROBIT_ACCELEROMETER_UNKNOWN                      0
+#define MICROBIT_ACCELEROMETER_MMA8653                      1
+#define MICROBIT_ACCELEROMETER_LSM303                       2
+#define MICROBIT_ACCELEROMETER_FXOS8700                     3
+
 struct ShakeHistory
 {
     uint16_t    shaken:1,
@@ -118,7 +123,7 @@ class MicroBitAccelerometer : public MicroBitComponent
 
     public:
 
-        static          MicroBitAccelerometer *detectedAccelerometer;       // The autodetected instance of a MicroBitAcelerometer driver.
+        static          MicroBitAccelerometer *detectedAccelerometer;       // The autodetected instance of a MicroBitAccelerometer driver.
 
         /**
          * Constructor.
@@ -323,6 +328,13 @@ class MicroBitAccelerometer : public MicroBitComponent
         {
             getSample();
         }
+        
+        /**
+         * Returns which accelerometer is detected
+         *
+         * @return MICROBIT_ACCELEROMETER_XXX
+         */
+        virtual uint8_t whatAmI();
 
         /**
          * Destructor.
@@ -365,6 +377,7 @@ class MicroBitAccelerometer : public MicroBitComponent
          * @return A 'best guess' of the current posture of the device, based on instanataneous data.
          */
         uint16_t instantaneousPosture();
+
 };
 
 #endif

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -289,12 +289,13 @@ void MicroBitBLEManager::deferredSysAttrWrite(Gap::Handle_t handle)
   * @param serialNumber The serial number exposed by the device information service
   * @param messageBus An instance of an EventModel, used during pairing.
   * @param enableBonding If true, the security manager enabled bonding.
+  * @param microbitModel The model of the micro:bit if detected
   *
   * @code
-  * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true);
+  * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true, uBit.getModel());
   * @endcode
   */
-void MicroBitBLEManager::init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, bool enableBonding)
+void MicroBitBLEManager::init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, bool enableBonding, ManagedString microbitModel)
 {
     ManagedString BLEName("BBC micro:bit");
     this->deviceName = deviceName;
@@ -387,7 +388,7 @@ void MicroBitBLEManager::init(ManagedString deviceName, ManagedString serialNumb
 #endif
 
 #if CONFIG_ENABLED(MICROBIT_BLE_DEVICE_INFORMATION_SERVICE)
-    DeviceInformationService ble_device_information_service(*ble, MICROBIT_BLE_MANUFACTURER, MICROBIT_BLE_MODEL, serialNumber.toCharArray(), MICROBIT_BLE_HARDWARE_VERSION, MICROBIT_BLE_FIRMWARE_VERSION, MICROBIT_BLE_SOFTWARE_VERSION);
+    DeviceInformationService ble_device_information_service(*ble, MICROBIT_BLE_MANUFACTURER, microbitModel.toCharArray(), serialNumber.toCharArray(), MICROBIT_BLE_HARDWARE_VERSION, MICROBIT_BLE_FIRMWARE_VERSION, MICROBIT_BLE_SOFTWARE_VERSION);
 #else
     (void)serialNumber;
 #endif
@@ -857,3 +858,4 @@ void MicroBitBLEManager::showNameHistogram(MicroBitDisplay &display)
 uint8_t MicroBitBLEManager::getCurrentMode(){
   return currentMode;
 }
+

--- a/source/drivers/FXOS8700.cpp
+++ b/source/drivers/FXOS8700.cpp
@@ -266,6 +266,16 @@ void FXOS8700::idleTick()
 }
 
 /**
+* Returns which accelerometer is detected
+*
+* @return MICROBIT_ACCELEROMETER_XXX
+*/
+uint8_t FXOS8700::whatAmI()
+{
+    return MICROBIT_ACCELEROMETER_FXOS8700;
+}
+
+/**
   * Destructor for FXS8700, where we deregister from the array of fiber components.
   */
 FXOS8700::~FXOS8700()

--- a/source/drivers/LSM303Accelerometer.cpp
+++ b/source/drivers/LSM303Accelerometer.cpp
@@ -201,6 +201,16 @@ int LSM303Accelerometer::isDetected(MicroBitI2C &i2c, uint16_t address)
 }
 
 /**
+* Returns which accelerometer is detected
+*
+* @return MICROBIT_ACCELEROMETER_XXX
+*/
+uint8_t LSM303Accelerometer::whatAmI()
+{
+    return MICROBIT_ACCELEROMETER_LSM303;
+}
+
+/**
  * Destructor.
  */
 LSM303Accelerometer::~LSM303Accelerometer()

--- a/source/drivers/MMA8653.cpp
+++ b/source/drivers/MMA8653.cpp
@@ -216,6 +216,16 @@ int MMA8653::isDetected(MicroBitI2C &i2c, uint16_t address)
 }
 
 /**
+* Returns which accelerometer is detected
+*
+* @return MICROBIT_ACCELEROMETER_XXX
+*/
+uint8_t MMA8653::whatAmI()
+{
+        return MICROBIT_ACCELEROMETER_MMA8653;
+}
+
+/**
  * Destructor.
  */
 MMA8653::~MMA8653()

--- a/source/drivers/MicroBitAccelerometer.cpp
+++ b/source/drivers/MicroBitAccelerometer.cpp
@@ -598,6 +598,16 @@ uint16_t MicroBitAccelerometer::getGesture()
 }
 
 /**
+ * Returns which accelerometer is detected
+ *
+ * @return MICROBIT_ACCELEROMETER_XXX
+ */
+uint8_t MicroBitAccelerometer::whatAmI()
+{
+    return MICROBIT_ACCELEROMETER_UNKNOWN;
+}
+
+/**
   * Destructor for FXS8700, where we deregister from the array of fiber components.
   */
 MicroBitAccelerometer::~MicroBitAccelerometer()


### PR DESCRIPTION
The micro:bit can detect what kind of micro:bit it is: 1.3x, 1.5x using by determining which accelerometer is in use.

This is then appended to "BBC micro:bit" in the Device Information Service.