### PR TITLE
Make microbit_heap_print() available externally

### DIFF
--- a/inc/core/MicroBitHeapAllocator.h
+++ b/inc/core/MicroBitHeapAllocator.h
@@ -83,5 +83,6 @@ struct HeapDefinition
   * simply use the standard heap.
   */
 int microbit_create_heap(uint32_t start, uint32_t end);
+void microbit_heap_print();
 
 #endif


### PR DESCRIPTION
The heap printing in MicrobitHeapAllocator is really useful for
gauging how much memory is free at various points in the program.

Specifically, by calling this after the uBit object is created we
can start to measure a high-water-mark for RAM and track it over
releases, etc