### PR TITLE
Moved restart into pairing mode code

### DIFF
--- a/inc/bluetooth/MicroBitBLEManager.h
+++ b/inc/bluetooth/MicroBitBLEManager.h
@@ -282,12 +282,6 @@ class MicroBitBLEManager : MicroBitComponent
     int advertiseEddystoneUid(const char* uid_namespace, const char* uid_instance, int8_t calibratedPower = MICROBIT_BLE_EDDYSTONE_DEFAULT_POWER, bool connectable = true, uint16_t interval = MICROBIT_BLE_EDDYSTONE_ADV_INTERVAL);
 #endif
 
-  /**
-   * Restarts in BLE Mode
-   *
-   */
-   void restartInBLEMode();
-
    /**
     * Get current BLE mode; application, pairing
     * #define MICROBIT_MODE_PAIRING     0x00

--- a/inc/core/MicroBitComponent.h
+++ b/inc/core/MicroBitComponent.h
@@ -73,6 +73,8 @@ DEALINGS IN THE SOFTWARE.
 #define MICROBIT_ID_IO_INT3             35          //INT3
 #define MICROBIT_ID_PARTIAL_FLASHING    36
 
+#define MICROBIT_ID_RESET_INTO_PAIRING  37
+
 #define MICROBIT_ID_MESSAGE_BUS_LISTENER            1021          // Message bus indication that a handler for a given ID has been registered.
 #define MICROBIT_ID_NOTIFY_ONE                      1022          // Notfication channel, for general purpose synchronisation
 #define MICROBIT_ID_NOTIFY                          1023          // Notfication channel, for general purpose synchronisation

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -842,20 +842,6 @@ void MicroBitBLEManager::showNameHistogram(MicroBitDisplay &display)
     }
 }
 
-/**
- * Restarts into BLE Mode
- *
- */
- void MicroBitBLEManager::restartInBLEMode(){
-   KeyValuePair* RebootMode = storage->get("RebootMode");
-   if(RebootMode == NULL){
-     uint8_t RebootModeValue = MICROBIT_MODE_PAIRING;
-     storage->put("RebootMode", &RebootModeValue, sizeof(RebootMode));
-     delete RebootMode;
-   }
-   microbit_reset();
- }
-
  /**
   * Get BLE mode. Returns the current mode: application, pairing mode
   */

--- a/source/bluetooth/MicroBitPartialFlashingService.cpp
+++ b/source/bluetooth/MicroBitPartialFlashingService.cpp
@@ -146,7 +146,7 @@ void MicroBitPartialFlashingService::onDataWritten(const GattWriteCallbackParams
            switch(data[1]) {
              case MICROBIT_MODE_PAIRING:
              {
-               MicroBitEvent evt(MICROBIT_ID_PARTIAL_FLASHING, MICROBIT_RESET );
+               MicroBitEvent evt(MICROBIT_ID_PARTIAL_FLASHING, MICROBIT_ID_RESET_INTO_PAIRING );
                break;
              }
              case MICROBIT_MODE_APPLICATION:
@@ -314,11 +314,6 @@ void MicroBitPartialFlashingService::partialFlashingEvent(MicroBitEvent e)
         MicroBitStorage storage;
         storage.remove("flashIncomplete");
         microbit_reset();
-      break;
-    }
-    case MICROBIT_RESET:
-    {
-      MicroBitBLEManager::manager->restartInBLEMode();
       break;
     }
   }


### PR DESCRIPTION
#392 

Moved the restart into pairing mode code to Microbit.cpp
It's #ifdef guarded to only compile if pairing mode exists in the build

I've left the source of the event here as MICROBIT_ID_PARTIAL_FLASHING. The event listener used now listens for any source but it may be useful in the future to know where the request to enter pairing mode has come from