### PR TITLE
Delay microbit_panic for 050 / 051 errors

### DIFF
--- a/source/drivers/MicroBitAccelerometer.cpp
+++ b/source/drivers/MicroBitAccelerometer.cpp
@@ -112,7 +112,8 @@ MicroBitAccelerometer& MicroBitAccelerometer::autoDetect(MicroBitI2C &i2c)
 
         else
         {
-            microbit_panic(MICROBIT_HARDWARE_UNAVAILABLE_ACC);
+            MicroBitAccelerometer *unavailable =  new MicroBitAccelerometer(coordinateSpace, MICROBIT_ID_ACCELEROMETER);
+            MicroBitAccelerometer::detectedAccelerometer = unavailable;
         }
     }
 
@@ -438,6 +439,7 @@ int MicroBitAccelerometer::configure()
  */
 int MicroBitAccelerometer::requestUpdate()
 {
+    microbit_panic(MICROBIT_HARDWARE_UNAVAILABLE_ACC);
     return MICROBIT_NOT_SUPPORTED;
 }
 

--- a/source/drivers/MicroBitCompass.cpp
+++ b/source/drivers/MicroBitCompass.cpp
@@ -134,7 +134,8 @@ MicroBitCompass& MicroBitCompass::autoDetect(MicroBitI2C &i2c)
 
         else
         {
-            microbit_panic(MICROBIT_HARDWARE_UNAVAILABLE_MAG);
+            MicroBitCompass *unavailable = new MicroBitCompass(coordinateSpace, MICROBIT_ID_COMPASS);
+            MicroBitCompass::detectedCompass = unavailable;
         }
     }
 
@@ -357,6 +358,7 @@ int MicroBitCompass::getPeriod()
  */
 int MicroBitCompass::requestUpdate()
 {
+    microbit_panic(MICROBIT_HARDWARE_UNAVAILABLE_MAG);
     return MICROBIT_NOT_SUPPORTED;
 }
 


### PR DESCRIPTION
This PR delays the microbit_panic call to the `requestUpdate()` function

A MicroBitAccelerometer / MicroBitCompass object is created rather than a device specific object, this allows the device to fall back to the default `requestUpdate()` function which now calls `microbit_panic()`

This function is only called if the user program requests data from the acc / mag, or sets up a listener for an event on the devices. If the program does not use the devices, the object is created but won't trigger the `requestUpdate()` / `microbit_panic()`

I've currently only tested this with a C++ build

------
@finneyj 