### PR TITLE
Reverse ordering of condition check [MicroBitSerial.cpp]

### DIFF
--- a/source/drivers/MicroBitSerial.cpp
+++ b/source/drivers/MicroBitSerial.cpp
@@ -646,7 +646,7 @@ int MicroBitSerial::read(uint8_t *buffer, int bufferLen, MicroBitSerialMode mode
 
     if(mode == ASYNC)
     {
-        while((temp = getChar(mode)) != MICROBIT_NO_DATA && bufferIndex < bufferLen)
+        while(bufferIndex < bufferLen && (temp = getChar(mode)) != MICROBIT_NO_DATA)
         {
             buffer[bufferIndex] = (char)temp;
             bufferIndex++;


### PR DESCRIPTION
A byte would be read and then dropped if bufferIndex >= bufferLen. Reversing the condition check fixes this bug.