### PR TITLE
MicroBitUARTService - wake up send() on disconnection

### DIFF
--- a/source/bluetooth/MicroBitUARTService.cpp
+++ b/source/bluetooth/MicroBitUARTService.cpp
@@ -55,6 +55,14 @@ void on_confirmation(uint16_t handle)
 }
 
 /**
+ * Callback when a BLE GATT disconnect occurs.
+ */
+static void bleDisconnectionCallback(const Gap::DisconnectionCallbackParams_t *reason)
+{
+    MicroBitEvent(MICROBIT_ID_NOTIFY, MICROBIT_UART_S_EVT_TX_EMPTY);
+}
+
+/**
  * Constructor for the UARTService.
  * @param _ble an instance of BLEDevice
  * @param rxBufferSize the size of the rxBuffer
@@ -92,6 +100,8 @@ MicroBitUARTService::MicroBitUARTService(BLEDevice &_ble, uint8_t rxBufferSize, 
 
     _ble.gattServer().onDataWritten(this, &MicroBitUARTService::onDataWritten);
     _ble.gattServer().onConfirmationReceived(on_confirmation);
+  
+    _ble.gap().onDisconnection( bleDisconnectionCallback);
 }
 
 /**


### PR DESCRIPTION
Using an onDisconnection callback, trigger the same event as on_confirmation to wake up send() if it's sleeping. Fixes #407.