### PR TITLE
Add support for Custom CMake

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -117,3 +117,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     target_compile_options(ble-nrf51822 PRIVATE "-w")
     target_compile_options(nrf51-sdk PRIVATE "-w")
 endif()
+
+if (YOTTA_CFG_MICROBIT_DAL_CUSTOM_CMAKE_SOURCE)
+include ("${YOTTA_CFG_MICROBIT_DAL_CUSTOM_CMAKE_SOURCE}")
+endif ()


### PR DESCRIPTION
This patch allow us to customize the behavior of `source/CMakeLists.txt`.

Example:
--- config.json ---
{
	"microbit-dal": {
		"custom_cmake": {
			"source": "CMakeLists.local.txt"
		}
	}
}
--- source/CMakeLists.local.txt ---
set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftabstop=4 -Warray-bounds=0")
