### PR TITLE
MicroBitAccelerometer: request an update before returning a gesture

### DIFF
--- a/source/drivers/MicroBitAccelerometer.cpp
+++ b/source/drivers/MicroBitAccelerometer.cpp
@@ -608,6 +608,7 @@ void MicroBitAccelerometer::recalculatePitchRoll()
   */
 uint16_t MicroBitAccelerometer::getGesture()
 {
+    requestUpdate();
     return lastGesture;
 }
 


### PR DESCRIPTION
I might have done something wrong but when I tried to call getGesture() in my code it would always return 0. Then I noticed that if getGesture got called right after a get[X,Y,Z] function it would return an actual gesture value.